### PR TITLE
Use the most recent auth selection

### DIFF
--- a/SyncKusto/MainForm.Designer.cs
+++ b/SyncKusto/MainForm.Designer.cs
@@ -150,7 +150,7 @@ namespace SyncKusto
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(81, 13);
             this.label2.TabIndex = 6;
-            this.label2.Text = "Build 20200626";
+            this.label2.Text = "Build 20201117";
             // 
             // spcTargetHolder
             // 

--- a/SyncKusto/SchemaPickerControl.cs
+++ b/SyncKusto/SchemaPickerControl.cs
@@ -71,7 +71,9 @@ namespace SyncKusto
         {
             get
             {
-                return QueryEngine.GetKustoConnectionStringBuilder(txtCluster.Text, txtDatabase.Text, txtAppId.Text, txtAppKey.Text);
+                return rbApplication.Checked
+                    ? QueryEngine.GetKustoConnectionStringBuilder(txtCluster.Text, txtDatabase.Text, txtAppId.Text, txtAppKey.Text)
+                    : QueryEngine.GetKustoConnectionStringBuilder(txtCluster.Text, txtDatabase.Text);
             }
         }
 


### PR DESCRIPTION
Fix for this bug:

1. Choose AAD App auth and enter bogus id and key
2. Click Compare
3. Switch to AAD user auth and click Compare again

In this situation, the code saw that the app id and app key text boxes still had text and it was using those to connect even though they weren't visible/selected.