### PR TITLE
Options for ".create-merge table" and one table field per line

### DIFF
--- a/SyncKusto/App.config
+++ b/SyncKusto/App.config
@@ -33,12 +33,4 @@
       </setting>
     </SyncKusto.Properties.Settings>
   </userSettings>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
 </configuration>

--- a/SyncKusto/App.config
+++ b/SyncKusto/App.config
@@ -25,6 +25,12 @@
       <setting name="KustoObjectDropWarning" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="TableFieldsOnNewLine" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="CreateMergeEnabled" serializeAs="String">
+        <value>False</value>
+      </setting>
     </SyncKusto.Properties.Settings>
   </userSettings>
   <runtime>

--- a/SyncKusto/ExtensionMethods.cs
+++ b/SyncKusto/ExtensionMethods.cs
@@ -108,7 +108,7 @@ namespace SyncKusto
                 Directory.CreateDirectory(tableFolder);
             }
 
-            File.WriteAllText(destinationFile, CslCommandGenerator.GenerateTableCreateCommand(tableSchema, true));
+            File.WriteAllText(destinationFile, FormattedCslCommandGenerator.GenerateTableCreateCommand(tableSchema, true));
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace SyncKusto
         /// <param name="kustoQueryEngine">An initialized query engine for issuing the Kusto command</param>
         public static void WriteToKusto(this TableSchema tableSchema, QueryEngine kustoQueryEngine)
         {
-            kustoQueryEngine.CreateOrAlterTableAsync(CslCommandGenerator.GenerateTableCreateCommand(tableSchema, false), tableSchema.Name).Wait();
+            kustoQueryEngine.CreateOrAlterTableAsync(FormattedCslCommandGenerator.GenerateTableCreateCommand(tableSchema, false), tableSchema.Name).Wait();
         }
 
         /// <summary>

--- a/SyncKusto/Kusto/FormattedCslCommandGenerator.cs
+++ b/SyncKusto/Kusto/FormattedCslCommandGenerator.cs
@@ -1,0 +1,37 @@
+﻿using Kusto.Data.Common;
+
+namespace SyncKusto.Kusto
+{
+    /// <summary>
+    /// If this tool wants to save CSL files that are formatted slightly differently than the Kusto default, the Kusto
+    /// calls to CslCommandGenerator can be wrapped in this class.
+    /// </summary>
+    public static class FormattedCslCommandGenerator
+    {
+        /// <summary>
+        /// Wrap the call to CslCommandGenerator.GenerateTableCreateCommand and allow special formatting if the user
+        /// has enabled the setting flag for it. Also choose between "create" and "create merge" based on setting
+        /// </summary>
+        /// <param name="table">The table schema to convert to a string</param>
+        /// <param name="forceNormalizeColumnName">True to force the column names to be normalized/escaped</param>
+        /// <returns></returns>
+        public static string GenerateTableCreateCommand(TableSchema table, bool forceNormalizeColumnName = false)
+        {
+            string result = SettingsWrapper.CreateMergeEnabled == true
+                ? CslCommandGenerator.GenerateTableCreateMergeCommandWithExtraProperties(table, forceNormalizeColumnName)
+                : CslCommandGenerator.GenerateTableCreateCommand(table, forceNormalizeColumnName);
+
+            if (SettingsWrapper.TableFieldsOnNewLine == true)
+            {
+                // Add a line break between each field
+                result = result.Replace(", ['", ",\r\n    ['");
+
+                // Add a line break before the first field
+                int parameterStartIndex = result.LastIndexOf("([");
+                result = result.Insert(parameterStartIndex + 1, "\r\n    ");
+            }
+
+            return result;
+        }
+    }
+}

--- a/SyncKusto/MainForm.Designer.cs
+++ b/SyncKusto/MainForm.Designer.cs
@@ -150,7 +150,7 @@ namespace SyncKusto
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(81, 13);
             this.label2.TabIndex = 6;
-            this.label2.Text = "Build 20201117";
+            this.label2.Text = "Build 20210430";
             // 
             // spcTargetHolder
             // 

--- a/SyncKusto/MainForm.cs
+++ b/SyncKusto/MainForm.cs
@@ -252,7 +252,7 @@ namespace SyncKusto
 
             if (_sourceSchema.Tables.ContainsKey(objectName) && e.Node.FullPath.StartsWith(_tablesTreeNodeText))
             {
-                sourceText = CslCommandGenerator.GenerateTableCreateCommand(_sourceSchema.Tables[objectName], true);
+                sourceText = FormattedCslCommandGenerator.GenerateTableCreateCommand(_sourceSchema.Tables[objectName], true);
             }
 
             if (_targetSchema.Functions.ContainsKey(objectName) && e.Node.FullPath.StartsWith(_functionTreeNodeText))
@@ -262,7 +262,7 @@ namespace SyncKusto
 
             if (_targetSchema.Tables.ContainsKey(objectName) && e.Node.FullPath.StartsWith(_tablesTreeNodeText))
             {
-                targetText = CslCommandGenerator.GenerateTableCreateCommand(_targetSchema.Tables[objectName], true);
+                targetText = FormattedCslCommandGenerator.GenerateTableCreateCommand(_targetSchema.Tables[objectName], true);
             }
 
             var diffBuilder = new InlineDiffBuilder(new Differ());

--- a/SyncKusto/Properties/Settings.Designer.cs
+++ b/SyncKusto/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace SyncKusto.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.5.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -80,6 +80,30 @@ namespace SyncKusto.Properties {
             }
             set {
                 this["KustoObjectDropWarning"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool TableFieldsOnNewLine {
+            get {
+                return ((bool)(this["TableFieldsOnNewLine"]));
+            }
+            set {
+                this["TableFieldsOnNewLine"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool CreateMergeEnabled {
+            get {
+                return ((bool)(this["CreateMergeEnabled"]));
+            }
+            set {
+                this["CreateMergeEnabled"] = value;
             }
         }
     }

--- a/SyncKusto/Properties/Settings.settings
+++ b/SyncKusto/Properties/Settings.settings
@@ -17,5 +17,11 @@
     <Setting Name="KustoObjectDropWarning" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="TableFieldsOnNewLine" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="CreateMergeEnabled" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/SyncKusto/SettingsForm.Designer.cs
+++ b/SyncKusto/SettingsForm.Designer.cs
@@ -46,29 +46,36 @@ namespace SyncKusto
             this.label1 = new System.Windows.Forms.Label();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.chkTableDropWarning = new System.Windows.Forms.CheckBox();
+            this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.cbTableFieldsOnNewLine = new System.Windows.Forms.CheckBox();
+            this.cbCreateMerge = new System.Windows.Forms.CheckBox();
+            this.label6 = new System.Windows.Forms.Label();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.groupBox3.SuspendLayout();
+            this.groupBox4.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnOk
             // 
-            this.btnOk.Location = new System.Drawing.Point(339, 560);
+            this.btnOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnOk.Location = new System.Drawing.Point(339, 727);
             this.btnOk.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnOk.Name = "btnOk";
             this.btnOk.Size = new System.Drawing.Size(112, 35);
-            this.btnOk.TabIndex = 3;
+            this.btnOk.TabIndex = 6;
             this.btnOk.Text = "O&K";
             this.btnOk.UseVisualStyleBackColor = true;
             this.btnOk.Click += new System.EventHandler(this.btnOk_Click);
             // 
             // btnCancel
             // 
-            this.btnCancel.Location = new System.Drawing.Point(460, 560);
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCancel.Location = new System.Drawing.Point(460, 727);
             this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(112, 35);
-            this.btnCancel.TabIndex = 4;
+            this.btnCancel.TabIndex = 7;
             this.btnCancel.Text = "&Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
@@ -77,12 +84,12 @@ namespace SyncKusto
             // 
             this.groupBox1.Controls.Add(this.txtAuthority);
             this.groupBox1.Controls.Add(this.label3);
-            this.groupBox1.Location = new System.Drawing.Point(18, 306);
+            this.groupBox1.Location = new System.Drawing.Point(18, 271);
             this.groupBox1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox1.Size = new System.Drawing.Size(554, 154);
-            this.groupBox1.TabIndex = 5;
+            this.groupBox1.TabIndex = 106;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "AAD Authority";
             // 
@@ -92,7 +99,7 @@ namespace SyncKusto
             this.txtAuthority.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtAuthority.Name = "txtAuthority";
             this.txtAuthority.Size = new System.Drawing.Size(534, 26);
-            this.txtAuthority.TabIndex = 6;
+            this.txtAuthority.TabIndex = 2;
             // 
             // label3
             // 
@@ -100,7 +107,7 @@ namespace SyncKusto
             this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(536, 85);
-            this.label3.TabIndex = 4;
+            this.label3.TabIndex = 107;
             this.label3.Text = resources.GetString("label3.Text");
             // 
             // groupBox2
@@ -115,7 +122,7 @@ namespace SyncKusto
             this.groupBox2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.groupBox2.Size = new System.Drawing.Size(554, 272);
+            this.groupBox2.Size = new System.Drawing.Size(554, 243);
             this.groupBox2.TabIndex = 6;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Temporary Databases";
@@ -123,65 +130,65 @@ namespace SyncKusto
             // label5
             // 
             this.label5.ForeColor = System.Drawing.Color.Red;
-            this.label5.Location = new System.Drawing.Point(9, 143);
+            this.label5.Location = new System.Drawing.Point(9, 122);
             this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(536, 32);
-            this.label5.TabIndex = 8;
+            this.label5.TabIndex = 101;
             this.label5.Text = "Everything in this database will be deleted.";
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(9, 225);
+            this.label4.Location = new System.Drawing.Point(9, 204);
             this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(83, 20);
-            this.label4.TabIndex = 7;
-            this.label4.Text = "Database:";
+            this.label4.TabIndex = 104;
+            this.label4.Text = "&Database:";
             // 
             // txtKustoDatabase
             // 
-            this.txtKustoDatabase.Location = new System.Drawing.Point(104, 220);
+            this.txtKustoDatabase.Location = new System.Drawing.Point(104, 199);
             this.txtKustoDatabase.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtKustoDatabase.Name = "txtKustoDatabase";
             this.txtKustoDatabase.Size = new System.Drawing.Size(439, 26);
-            this.txtKustoDatabase.TabIndex = 6;
+            this.txtKustoDatabase.TabIndex = 1;
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(9, 185);
+            this.label2.Location = new System.Drawing.Point(9, 164);
             this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(63, 20);
-            this.label2.TabIndex = 5;
-            this.label2.Text = "Cluster:";
+            this.label2.TabIndex = 103;
+            this.label2.Text = "C&luster:";
             // 
             // txtKustoCluster
             // 
-            this.txtKustoCluster.Location = new System.Drawing.Point(104, 180);
+            this.txtKustoCluster.Location = new System.Drawing.Point(104, 159);
             this.txtKustoCluster.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtKustoCluster.Name = "txtKustoCluster";
             this.txtKustoCluster.Size = new System.Drawing.Size(439, 26);
-            this.txtKustoCluster.TabIndex = 4;
+            this.txtKustoCluster.TabIndex = 0;
             // 
             // label1
             // 
             this.label1.Location = new System.Drawing.Point(9, 32);
             this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(536, 111);
-            this.label1.TabIndex = 3;
+            this.label1.Size = new System.Drawing.Size(536, 90);
+            this.label1.TabIndex = 100;
             this.label1.Text = resources.GetString("label1.Text");
             // 
             // groupBox3
             // 
             this.groupBox3.Controls.Add(this.chkTableDropWarning);
-            this.groupBox3.Location = new System.Drawing.Point(18, 469);
+            this.groupBox3.Location = new System.Drawing.Point(18, 434);
             this.groupBox3.Name = "groupBox3";
             this.groupBox3.Size = new System.Drawing.Size(554, 83);
-            this.groupBox3.TabIndex = 7;
+            this.groupBox3.TabIndex = 108;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Warnings";
             // 
@@ -191,15 +198,62 @@ namespace SyncKusto
             this.chkTableDropWarning.Location = new System.Drawing.Point(13, 35);
             this.chkTableDropWarning.Name = "chkTableDropWarning";
             this.chkTableDropWarning.Size = new System.Drawing.Size(438, 24);
-            this.chkTableDropWarning.TabIndex = 0;
-            this.chkTableDropWarning.Text = "Ask before dropping objects in the target Kusto database";
+            this.chkTableDropWarning.TabIndex = 3;
+            this.chkTableDropWarning.Text = "&Ask before dropping objects in the target Kusto database";
             this.chkTableDropWarning.UseVisualStyleBackColor = true;
+            // 
+            // groupBox4
+            // 
+            this.groupBox4.Controls.Add(this.label6);
+            this.groupBox4.Controls.Add(this.cbCreateMerge);
+            this.groupBox4.Controls.Add(this.cbTableFieldsOnNewLine);
+            this.groupBox4.Location = new System.Drawing.Point(18, 523);
+            this.groupBox4.Name = "groupBox4";
+            this.groupBox4.Size = new System.Drawing.Size(554, 185);
+            this.groupBox4.TabIndex = 109;
+            this.groupBox4.TabStop = false;
+            this.groupBox4.Text = "Formatting";
+            // 
+            // cbTableFieldsOnNewLine
+            // 
+            this.cbTableFieldsOnNewLine.AutoSize = true;
+            this.cbTableFieldsOnNewLine.Location = new System.Drawing.Point(13, 35);
+            this.cbTableFieldsOnNewLine.Name = "cbTableFieldsOnNewLine";
+            this.cbTableFieldsOnNewLine.Size = new System.Drawing.Size(245, 24);
+            this.cbTableFieldsOnNewLine.TabIndex = 4;
+            this.cbTableFieldsOnNewLine.Text = "&Place table fields on new lines";
+            this.cbTableFieldsOnNewLine.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.cbTableFieldsOnNewLine.UseVisualStyleBackColor = true;
+            // 
+            // cbCreateMerge
+            // 
+            this.cbCreateMerge.AutoSize = true;
+            this.cbCreateMerge.Location = new System.Drawing.Point(13, 65);
+            this.cbCreateMerge.Name = "cbCreateMerge";
+            this.cbCreateMerge.Size = new System.Drawing.Size(517, 24);
+            this.cbCreateMerge.TabIndex = 5;
+            this.cbCreateMerge.Text = "&Generate \".create-merge table\" commands instead of \".create table\"";
+            this.cbCreateMerge.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.cbCreateMerge.UseVisualStyleBackColor = true;
+            // 
+            // label6
+            // 
+            this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.label6.Location = new System.Drawing.Point(9, 115);
+            this.label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(534, 67);
+            this.label6.TabIndex = 110;
+            this.label6.Text = resources.GetString("label6.Text");
             // 
             // SettingsForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(590, 607);
+            this.ClientSize = new System.Drawing.Size(590, 774);
+            this.Controls.Add(this.groupBox4);
             this.Controls.Add(this.groupBox3);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.groupBox1);
@@ -217,6 +271,8 @@ namespace SyncKusto
             this.groupBox2.PerformLayout();
             this.groupBox3.ResumeLayout(false);
             this.groupBox3.PerformLayout();
+            this.groupBox4.ResumeLayout(false);
+            this.groupBox4.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -236,5 +292,9 @@ namespace SyncKusto
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.GroupBox groupBox3;
         private System.Windows.Forms.CheckBox chkTableDropWarning;
+        private System.Windows.Forms.GroupBox groupBox4;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.CheckBox cbCreateMerge;
+        private System.Windows.Forms.CheckBox cbTableFieldsOnNewLine;
     }
 }

--- a/SyncKusto/SettingsForm.cs
+++ b/SyncKusto/SettingsForm.cs
@@ -35,6 +35,8 @@ namespace SyncKusto
             txtKustoDatabase.Text = SettingsWrapper.TemporaryKustoDatabase;
             txtAuthority.Text = SettingsWrapper.AADAuthority;
             chkTableDropWarning.Checked = SettingsWrapper.KustoObjectDropWarning;
+            cbTableFieldsOnNewLine.Checked = SettingsWrapper.TableFieldsOnNewLine ?? false;
+            cbCreateMerge.Checked = SettingsWrapper.CreateMergeEnabled ?? false;
         }
 
         /// <summary>
@@ -56,6 +58,10 @@ namespace SyncKusto
         {
             Cursor lastCursor = Cursor.Current;
             Cursor.Current = Cursors.WaitCursor;
+
+            SettingsWrapper.TableFieldsOnNewLine = cbTableFieldsOnNewLine.Checked;
+            SettingsWrapper.CreateMergeEnabled = cbCreateMerge.Checked;
+            SettingsWrapper.KustoObjectDropWarning = chkTableDropWarning.Checked;
 
             // Allow for multiple ways of specifying a cluster name
             if (string.IsNullOrEmpty(txtKustoCluster.Text))
@@ -99,7 +105,6 @@ namespace SyncKusto
                 SettingsWrapper.KustoClusterForTempDatabases = clusterName;
                 SettingsWrapper.TemporaryKustoDatabase = databaseName;
                 SettingsWrapper.AADAuthority = txtAuthority.Text;
-                SettingsWrapper.KustoObjectDropWarning = chkTableDropWarning.Checked;
 
                 this.Close();
             }

--- a/SyncKusto/SettingsForm.resx
+++ b/SyncKusto/SettingsForm.resx
@@ -121,7 +121,10 @@
     <value>Specify the AAD authority to be used for authentication (e.g. contoso.com). Depending on your tenant configuration, this may be optional, unless you're connecting with an application id in which case it is required:</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>When the local file system is selected as the source or the target, SyncKusto loads all of the files into a temporary database and then asks Kusto for the database schema. Specify a Kusto cluster and database to use for the comparison. The user must have permissions to delete everything in the database and create new functions and tables.</value>
+    <value>When the local file system is selected as the source or the target, SyncKusto loads all of the files into a temporary database and then asks Kusto for the database schema. Specify a Kusto cluster and database to use for the comparison. You must be a database admin.</value>
+  </data>
+  <data name="label6.Text" xml:space="preserve">
+    <value>These settings are only applied when a file is written. They do not affect the comparison operation. To apply this to all existing files, delete all the files locally, execute the comparison again and then update the local files.</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/SyncKusto/SettingsWrapper.cs
+++ b/SyncKusto/SettingsWrapper.cs
@@ -79,5 +79,31 @@ namespace SyncKusto
                 Settings.Default.Save();
             }
         }
+
+        /// <summary>
+        /// If true, every table field will get it's own line in the resulting CSL file
+        /// </summary>
+        public static bool? TableFieldsOnNewLine
+        {
+            get => Settings.Default["TableFieldsOnNewLine"] as bool?;
+            set
+            {
+                Settings.Default["TableFieldsOnNewLine"] = value;
+                Settings.Default.Save();
+            }
+        }
+
+        /// <summary>
+        /// If true, table create commands will be ".create-merge table" instead of ".create table"
+        /// </summary>
+        public static bool? CreateMergeEnabled
+        {
+            get => Settings.Default["CreateMergeEnabled"] as bool?;
+            set
+            {
+                Settings.Default["CreateMergeEnabled"] = value;
+                Settings.Default.Save();
+            }
+        }
     }
 }

--- a/SyncKusto/SyncKusto.csproj
+++ b/SyncKusto/SyncKusto.csproj
@@ -231,10 +231,10 @@
       <Version>1.4.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.Kusto.Data">
-      <Version>8.1.2</Version>
+      <Version>9.2.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.2</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>

--- a/SyncKusto/SyncKusto.csproj
+++ b/SyncKusto/SyncKusto.csproj
@@ -110,6 +110,7 @@
     <Compile Include="DropWarningForm.Designer.cs">
       <DependentUpon>DropWarningForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="Kusto\FormattedCslCommandGenerator.cs" />
     <Compile Include="SettingsForm.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
Two new settings are added. Both are disabled by default:
- Generate ".create-merge table" instead of ".create table" commands
- When generating table commands, put each field on a new line. This makes it easier to identify changes in tables with many fields.

This also contains an update to NuGet packages.