### PR TITLE
Faster database wiping and more checks for temp database

### DIFF
--- a/SyncKusto/Kusto/DatabaseSchemaBuilder/FileDatabaseSchemaBuilder.cs
+++ b/SyncKusto/Kusto/DatabaseSchemaBuilder/FileDatabaseSchemaBuilder.cs
@@ -51,7 +51,7 @@ namespace SyncKusto.Kusto.DatabaseSchemaBuilder
                     var tableTasks = new List<Task>();
                     foreach (string table in tableFiles)
                     {
-                        tableTasks.Add(queryEngine.CreateOrAlterTableAsync(File.ReadAllText(table), Path.GetFileName(table)));
+                        tableTasks.Add(queryEngine.CreateOrAlterTableAsync(File.ReadAllText(table), Path.GetFileName(table), true));
                     }
                     failedObjects.AddRange(WaitAllAndGetFailedObjects(tableTasks));
 

--- a/SyncKusto/Kusto/QueryEngine.cs
+++ b/SyncKusto/Kusto/QueryEngine.cs
@@ -71,17 +71,13 @@ namespace SyncKusto.Kusto
             }
 
             var schema = GetDatabaseSchema();
-            foreach (var function in schema.Functions)
-            {
-                string command = CslCommandGenerator.GenerateFunctionDropCommand(function.Value.Name, true);
-                _adminClient.ExecuteControlCommand(command);
-            }
-
-            foreach (var table in schema.Tables)
-            {
-                string command = CslCommandGenerator.GenerateTableDropCommand(table.Value.Name, true);
-                _adminClient.ExecuteControlCommand(command);
-            }
+            
+            _adminClient.ExecuteControlCommand(
+                CslCommandGenerator.GenerateFunctionsDropCommand(
+                    schema.Functions.Select(f => f.Value.Name), true));
+            _adminClient.ExecuteControlCommand(
+                CslCommandGenerator.GenerateTablesDropCommand(
+                    schema.Tables.Select(f => f.Value.Name), true));
         }
 
         /// <summary>

--- a/SyncKusto/Kusto/QueryEngine.cs
+++ b/SyncKusto/Kusto/QueryEngine.cs
@@ -67,17 +67,24 @@ namespace SyncKusto.Kusto
         {
             if (!_tempDatabaseUsed)
             {
-                throw new Exception("CleanDatabase() was called on something other than the temporary database. This method will wipe out the entire database schema and data.");
+                throw new Exception("CleanDatabase() was called on something other than the temporary database.");
             }
 
             var schema = GetDatabaseSchema();
-            
-            _adminClient.ExecuteControlCommand(
-                CslCommandGenerator.GenerateFunctionsDropCommand(
-                    schema.Functions.Select(f => f.Value.Name), true));
-            _adminClient.ExecuteControlCommand(
-                CslCommandGenerator.GenerateTablesDropCommand(
-                    schema.Tables.Select(f => f.Value.Name), true));
+
+            if (schema.Functions.Count > 0)
+            {
+                _adminClient.ExecuteControlCommand(
+                    CslCommandGenerator.GenerateFunctionsDropCommand(
+                        schema.Functions.Select(f => f.Value.Name), true));
+            }
+
+            if (schema.Tables.Count > 0)
+            {
+                _adminClient.ExecuteControlCommand(
+                    CslCommandGenerator.GenerateTablesDropCommand(
+                        schema.Tables.Select(f => f.Value.Name), true));
+            }
         }
 
         /// <summary>

--- a/SyncKusto/MainForm.Designer.cs
+++ b/SyncKusto/MainForm.Designer.cs
@@ -150,7 +150,7 @@ namespace SyncKusto
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(81, 13);
             this.label2.TabIndex = 6;
-            this.label2.Text = "Build 20210430";
+            this.label2.Text = "Build 20210503";
             // 
             // spcTargetHolder
             // 

--- a/SyncKusto/SettingsForm.Designer.cs
+++ b/SyncKusto/SettingsForm.Designer.cs
@@ -47,9 +47,9 @@ namespace SyncKusto
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.chkTableDropWarning = new System.Windows.Forms.CheckBox();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
-            this.cbTableFieldsOnNewLine = new System.Windows.Forms.CheckBox();
-            this.cbCreateMerge = new System.Windows.Forms.CheckBox();
             this.label6 = new System.Windows.Forms.Label();
+            this.cbCreateMerge = new System.Windows.Forms.CheckBox();
+            this.cbTableFieldsOnNewLine = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.groupBox3.SuspendLayout();
@@ -135,7 +135,7 @@ namespace SyncKusto
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(536, 32);
             this.label5.TabIndex = 101;
-            this.label5.Text = "Everything in this database will be deleted.";
+            this.label5.Text = "Everything in this database will be deleted every time a comparison is done.";
             // 
             // label4
             // 
@@ -214,16 +214,17 @@ namespace SyncKusto
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Formatting";
             // 
-            // cbTableFieldsOnNewLine
+            // label6
             // 
-            this.cbTableFieldsOnNewLine.AutoSize = true;
-            this.cbTableFieldsOnNewLine.Location = new System.Drawing.Point(13, 35);
-            this.cbTableFieldsOnNewLine.Name = "cbTableFieldsOnNewLine";
-            this.cbTableFieldsOnNewLine.Size = new System.Drawing.Size(245, 24);
-            this.cbTableFieldsOnNewLine.TabIndex = 4;
-            this.cbTableFieldsOnNewLine.Text = "&Place table fields on new lines";
-            this.cbTableFieldsOnNewLine.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            this.cbTableFieldsOnNewLine.UseVisualStyleBackColor = true;
+            this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.label6.Location = new System.Drawing.Point(9, 115);
+            this.label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(534, 67);
+            this.label6.TabIndex = 110;
+            this.label6.Text = resources.GetString("label6.Text");
             // 
             // cbCreateMerge
             // 
@@ -236,17 +237,16 @@ namespace SyncKusto
             this.cbCreateMerge.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.cbCreateMerge.UseVisualStyleBackColor = true;
             // 
-            // label6
+            // cbTableFieldsOnNewLine
             // 
-            this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.label6.Location = new System.Drawing.Point(9, 115);
-            this.label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(534, 67);
-            this.label6.TabIndex = 110;
-            this.label6.Text = resources.GetString("label6.Text");
+            this.cbTableFieldsOnNewLine.AutoSize = true;
+            this.cbTableFieldsOnNewLine.Location = new System.Drawing.Point(13, 35);
+            this.cbTableFieldsOnNewLine.Name = "cbTableFieldsOnNewLine";
+            this.cbTableFieldsOnNewLine.Size = new System.Drawing.Size(245, 24);
+            this.cbTableFieldsOnNewLine.TabIndex = 4;
+            this.cbTableFieldsOnNewLine.Text = "&Place table fields on new lines";
+            this.cbTableFieldsOnNewLine.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.cbTableFieldsOnNewLine.UseVisualStyleBackColor = true;
             // 
             // SettingsForm
             // 

--- a/SyncKusto/SettingsForm.Designer.cs
+++ b/SyncKusto/SettingsForm.Designer.cs
@@ -135,7 +135,7 @@ namespace SyncKusto
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(536, 32);
             this.label5.TabIndex = 101;
-            this.label5.Text = "Everything in this database will be deleted every time a comparison is done.";
+            this.label5.Text = "Everything in this database will be dropped before every comparison!";
             // 
             // label4
             // 

--- a/SyncKusto/SettingsForm.cs
+++ b/SyncKusto/SettingsForm.cs
@@ -147,7 +147,11 @@ namespace SyncKusto
 
                     if (functionCount != 0 || tableCount != 0)
                     {
-                        MessageBox.Show($"Drop all functions and tables in the database before specifying this as the temporary database.", "Error Validating Empty Database", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show($"Drop all functions and tables in the {txtKustoDatabase.Text} database before specifying this as the temporary database. " +
+                            $"This check is performed to reinforce the point that this databse will be wiped every time a comparison is run.", 
+                            "Error Validating Empty Database", 
+                            MessageBoxButtons.OK, 
+                            MessageBoxIcon.Error);
                         return;
                     }
                 }

--- a/SyncKusto/SettingsForm.cs
+++ b/SyncKusto/SettingsForm.cs
@@ -62,28 +62,30 @@ namespace SyncKusto
             SettingsWrapper.TableFieldsOnNewLine = cbTableFieldsOnNewLine.Checked;
             SettingsWrapper.CreateMergeEnabled = cbCreateMerge.Checked;
             SettingsWrapper.KustoObjectDropWarning = chkTableDropWarning.Checked;
+            SettingsWrapper.AADAuthority = txtAuthority.Text;
 
-            // Allow for multiple ways of specifying a cluster name
-            if (string.IsNullOrEmpty(txtKustoCluster.Text))
+            // Only check the Kusto settings if they changed
+            if (SettingsWrapper.KustoClusterForTempDatabases != txtKustoCluster.Text || SettingsWrapper.TemporaryKustoDatabase != txtKustoDatabase.Text)
             {
-                MessageBox.Show($"No Kusto cluster was specified.", "Missing Info", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return;
-            }
-            string clusterName = QueryEngine.NormalizeClusterName(txtKustoCluster.Text);
+                // Allow for multiple ways of specifying a cluster name
+                if (string.IsNullOrEmpty(txtKustoCluster.Text))
+                {
+                    MessageBox.Show($"No Kusto cluster was specified.", "Missing Info", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return;
+                }
+                string clusterName = QueryEngine.NormalizeClusterName(txtKustoCluster.Text);
 
-            string databaseName = txtKustoDatabase.Text;
-            if (string.IsNullOrEmpty(databaseName))
-            {
-                MessageBox.Show($"No Kusto database was specified.", "Missing Info", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return;
-            }
+                string databaseName = txtKustoDatabase.Text;
+                if (string.IsNullOrEmpty(databaseName))
+                {
+                    MessageBox.Show($"No Kusto database was specified.", "Missing Info", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return;
+                }
 
-            // If the required info is present, update the cluster textbox with the modified cluster url
-            txtKustoCluster.Text = clusterName;
+                // If the required info is present, update the cluster textbox with the modified cluster url
+                txtKustoCluster.Text = clusterName;
 
-            // Verify connection and permissions by creating and removing a function
-            try
-            {
+                // Verify connection and permissions by creating and removing a function
                 var connString = new KustoConnectionStringBuilder(clusterName)
                 {
                     FederatedSecurity = true,
@@ -91,42 +93,75 @@ namespace SyncKusto
                     Authority = txtAuthority.Text
                 };
                 var adminClient = KustoClientFactory.CreateCslAdminProvider(connString);
-                string functionName = "SyncKustoPermissionsTest";
-                adminClient.ExecuteControlCommand(
-                    CslCommandGenerator.GenerateCreateOrAlterFunctionCommand(
-                        functionName, 
-                        "", 
-                        "",
-                        new Dictionary<string, string>(),
-                        "{print now()}"));
-                adminClient.ExecuteControlCommand(CslCommandGenerator.GenerateFunctionDropCommand(functionName));
 
+                try
+                {
+                    string functionName = "SyncKustoPermissionsTest" + Guid.NewGuid();
+                    adminClient.ExecuteControlCommand(
+                        CslCommandGenerator.GenerateCreateOrAlterFunctionCommand(
+                            functionName,
+                            "",
+                            "",
+                            new Dictionary<string, string>(),
+                            "{print now()}"));
+                    adminClient.ExecuteControlCommand(CslCommandGenerator.GenerateFunctionDropCommand(functionName));
+                }
+                catch (Exception ex)
+                {
+                    if (ex.Message.Contains("403-Forbidden"))
+                    {
+                        MessageBox.Show($"The current user does not have permission to create a function on cluster('{clusterName}').database('{databaseName}')", "Error Validating Permissions", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+                    else if (ex.Message.Contains("failed to resolve the service name"))
+                    {
+                        MessageBox.Show($"Cluster {clusterName} could not be found.", "Error Validating Permissions", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+                    else if (ex.Message.Contains("Kusto client failed to perform authentication"))
+                    {
+                        MessageBox.Show($"Could not authenticate with AAD. Please verify that the AAD Authority is specified correctly.", "Error Authenticating", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+                    else
+                    {
+                        MessageBox.Show($"Unknown error: {ex.Message}", "Error Validating Permissions", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+                    return;
+                }
+
+                // Verify that the scratch database is empty
+                try
+                {
+                    long functionCount = 0;
+                    long tableCount = 0;
+
+                    using (var functionReader = adminClient.ExecuteControlCommand(".show functions | count"))
+                    {
+                        functionReader.Read();
+                        functionCount = functionReader.GetInt64(0);
+                    }
+
+                    using (var tableReader = adminClient.ExecuteControlCommand(".show tables | count"))
+                    {
+                        tableReader.Read();
+                        tableCount = tableReader.GetInt64(0);
+                    }
+
+                    if (functionCount != 0 || tableCount != 0)
+                    {
+                        MessageBox.Show($"Drop all functions and tables in the database before specifying this as the temporary database.", "Error Validating Empty Database", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"Unknown error: {ex.Message}", "Error Validating Empty Database", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return;
+                }
                 // Store the settings now that we know they work
                 SettingsWrapper.KustoClusterForTempDatabases = clusterName;
                 SettingsWrapper.TemporaryKustoDatabase = databaseName;
-                SettingsWrapper.AADAuthority = txtAuthority.Text;
+            }
 
-                this.Close();
-            }
-            catch (Exception ex)
-            {
-                if (ex.Message.Contains("403-Forbidden"))
-                {
-                    MessageBox.Show($"The current user does not have permission to create a function on cluster('{clusterName}').database('{databaseName}')", "Error Validating Permissions", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
-                else if (ex.Message.Contains("failed to resolve the service name"))
-                {
-                    MessageBox.Show($"Cluster {clusterName} could not be found.", "Error Validating Permissions", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
-                else if (ex.Message.Contains("Kusto client failed to perform authentication"))
-                {
-                    MessageBox.Show($"Could not authenticate with AAD. Please verify that the AAD Authority is specified correctly.", "Error Authenticating", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
-                else
-                {
-                    MessageBox.Show($"Unknown error: {ex.Message}", "Error Validating Permissions", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
-            }
+            this.Close();
 
             Cursor.Current = lastCursor;
         }


### PR DESCRIPTION
- When the temp database is wiped to start a comparison, only two commands are executed (.drop functions and .drop tables) instead of dropping each object individually.
- When adjusting the settings, the user must now specify an EMPTY database as the temp database as a further communication that the temp database will be wiped every time the tool is run with a file source or target.
- The function to create or alter a table now has an option to skip the "alter" command for cases where the caller knows that the table does not exist yet. This is a perf improvement when building a fresh database from a set of CSL files but it is not used when updating the target schema with changes after a diff.