### PR TITLE
Support long paths

### DIFF
--- a/SyncKusto/MainForm.Designer.cs
+++ b/SyncKusto/MainForm.Designer.cs
@@ -150,7 +150,7 @@ namespace SyncKusto
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(81, 13);
             this.label2.TabIndex = 6;
-            this.label2.Text = "Build 20230104";
+            this.label2.Text = "Build 20230607";
             // 
             // spcTargetHolder
             // 


### PR DESCRIPTION
This is a fix for issue #30 . Long paths are now supported! There is more info on the approach here: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces