### PR TITLE
Selective application of long name syntax

### DIFF
--- a/SyncKusto/Kusto/DatabaseSchemaBuilder/FileDatabaseSchemaBuilder.cs
+++ b/SyncKusto/Kusto/DatabaseSchemaBuilder/FileDatabaseSchemaBuilder.cs
@@ -63,14 +63,14 @@ namespace SyncKusto.Kusto.DatabaseSchemaBuilder
                     var tableTasks = new List<Task>();
                     foreach (string table in tableFiles)
                     {
-                        tableTasks.Add(queryEngine.CreateOrAlterTableAsync(File.ReadAllText(table), Path.GetFileName(table), true));
+                        tableTasks.Add(queryEngine.CreateOrAlterTableAsync(File.ReadAllText(table.HandleLongFileNames()), Path.GetFileName(table), true));
                     }
                     failedObjects.AddRange(WaitAllAndGetFailedObjects(tableTasks));
 
                     var functionTasks = new List<Task>();
                     foreach (string function in functionFiles)
                     {
-                        string csl = File.ReadAllText(function);
+                        string csl = File.ReadAllText(function.HandleLongFileNames());
                         functionTasks.Add(queryEngine.CreateOrAlterFunctionAsync(csl, Path.GetFileName(function)));
                     }
                     failedObjects.AddRange(WaitAllAndGetFailedObjects(functionTasks));

--- a/SyncKusto/MainForm.Designer.cs
+++ b/SyncKusto/MainForm.Designer.cs
@@ -150,7 +150,7 @@ namespace SyncKusto
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(81, 13);
             this.label2.TabIndex = 6;
-            this.label2.Text = "Build 20230607";
+            this.label2.Text = "Build 20231110";
             // 
             // spcTargetHolder
             // 

--- a/SyncKusto/SchemaPickerControl.cs
+++ b/SyncKusto/SchemaPickerControl.cs
@@ -65,11 +65,7 @@ namespace SyncKusto
         private AuthenticationMode Authentication =>
             rbFederated.Checked ? AuthenticationMode.AadFederated : AuthenticationMode.AadApplication;
 
-        private string longPathPrefx = "\\\\?\\";
-
-        // Convert to long path to avoid issues with long file names
-        // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces
-        public string SourceFilePath => txtFilePath.Text.StartsWith(longPathPrefx) ? txtFilePath.Text : longPathPrefx + txtFilePath.Text;
+        public string SourceFilePath => txtFilePath.Text.HandleLongFileNames();
 
         public KustoConnectionStringBuilder KustoConnection
         {


### PR DESCRIPTION
The previous change added support for long names by adding it everywhere. Some users have long file names disabled on their machines which means the tool is always broken for them. With this change, long file names are only applied when the path gets long enough to need it, whether the initial directory was too long or whether the resulting filename is too long.