### PR TITLE
Update Kusto language nuget package

### DIFF
--- a/SyncKusto/MainForm.Designer.cs
+++ b/SyncKusto/MainForm.Designer.cs
@@ -150,7 +150,7 @@ namespace SyncKusto
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(81, 13);
             this.label2.TabIndex = 6;
-            this.label2.Text = "Build 20231110";
+            this.label2.Text = "Build 20240208";
             // 
             // spcTargetHolder
             // 

--- a/SyncKusto/MainForm.cs
+++ b/SyncKusto/MainForm.cs
@@ -104,7 +104,6 @@ namespace SyncKusto
                     FilePathOperationErrorSpecifications.FolderNotFound()
                 });
 
-
             spcSource.ReportProgress($@"Loading source schema...");
             IDatabaseSchema sourceSchema = TryGetSchema(() => spcSource.TryLoadSchema());
 

--- a/SyncKusto/SyncKusto.csproj
+++ b/SyncKusto/SyncKusto.csproj
@@ -231,10 +231,10 @@
       <Version>1.4.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.Kusto.Data">
-      <Version>9.4.1</Version>
+      <Version>12.0.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.2</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>


### PR DESCRIPTION
This fixes a report that the "view=true" attribute on functions was causing SyncKusto to throw an exception.