### PR TITLE
Support SubjectName/Issuer (SendX5c) auth

### DIFF
--- a/SyncKusto/Kusto/AuthenticationMode.cs
+++ b/SyncKusto/Kusto/AuthenticationMode.cs
@@ -4,11 +4,12 @@
 namespace SyncKusto.Kusto
 {
     /// <summary>
-    /// When connecting to a Kusto cluster, this enum contains the multiple methods of authentication are supported. 
+    /// When connecting to a Kusto cluster, this enum contains the multiple methods of authentication are supported.
     /// </summary>
     public enum AuthenticationMode
     {
         AadFederated,
-        AadApplication
+        AadApplication,
+        AadApplicationSni
     };
 }

--- a/SyncKusto/Kusto/QueryEngine.cs
+++ b/SyncKusto/Kusto/QueryEngine.cs
@@ -238,6 +238,11 @@ namespace SyncKusto.Kusto
                 throw new ArgumentException("If either aadClientId or aadClientKey are specified, they must both be specified.");
             }
 
+            if (string.IsNullOrWhiteSpace(SettingsWrapper.AADAuthority))
+            {
+                throw new Exception("Authority value must be specified in the Settings dialog.");
+            }
+
             cluster = NormalizeClusterName(cluster);
 
             // User auth

--- a/SyncKusto/Kusto/QueryEngine.cs
+++ b/SyncKusto/Kusto/QueryEngine.cs
@@ -10,6 +10,7 @@ using Kusto.Data;
 using Kusto.Data.Common;
 using Kusto.Data.Net.Client;
 using Newtonsoft.Json;
+using SyncKusto.Utilities;
 
 namespace SyncKusto.Kusto
 {
@@ -222,33 +223,65 @@ namespace SyncKusto.Kusto
         /// <param name="database">The name of the database to connect to</param>
         /// <param name="aadClientId">Optionally connect with AAD client app</param>
         /// <param name="aadClientKey">Optional key for AAD client app</param>
+        /// <param name="certificateThumbprint">Optional thumbprint of a certificate to use for Subject Name Issuer authentication</param>
         /// <returns>A connection string for accessing Kusto</returns>
-        public static KustoConnectionStringBuilder GetKustoConnectionStringBuilder(string cluster, string database, string aadClientId = null, string aadClientKey = null)
+        public static KustoConnectionStringBuilder GetKustoConnectionStringBuilder(
+            string cluster,
+            string database,
+            string aadClientId = null,
+            string aadClientKey = null,
+            string certificateThumbprint = null)
         {
-            if (string.IsNullOrEmpty(aadClientId) != string.IsNullOrEmpty(aadClientKey))
+            if (string.IsNullOrEmpty(aadClientId) != string.IsNullOrEmpty(aadClientKey) &&
+                string.IsNullOrEmpty(aadClientId) != string.IsNullOrEmpty(certificateThumbprint))
             {
                 throw new ArgumentException("If either aadClientId or aadClientKey are specified, they must both be specified.");
             }
 
             cluster = NormalizeClusterName(cluster);
 
-            var kcsb = new KustoConnectionStringBuilder(cluster)
+            // User auth
+            if (string.IsNullOrWhiteSpace(aadClientId))
             {
-                FederatedSecurity = true,
-                InitialCatalog = database,
-                Authority = SettingsWrapper.AADAuthority
-            };
-            if (!string.IsNullOrWhiteSpace(aadClientId) && !string.IsNullOrWhiteSpace(aadClientKey))
-            {
-                kcsb.ApplicationKey = aadClientKey;
-                kcsb.ApplicationClientId = aadClientId;
+                return new KustoConnectionStringBuilder(cluster)
+                {
+                    FederatedSecurity = true,
+                    InitialCatalog = database,
+                    Authority = SettingsWrapper.AADAuthority
+                };
             }
 
-            return kcsb;
+            // App Key auth
+            if (!string.IsNullOrWhiteSpace(aadClientId) && !string.IsNullOrWhiteSpace(aadClientKey))
+            {
+                return new KustoConnectionStringBuilder(cluster)
+                {
+                    FederatedSecurity = true,
+                    InitialCatalog = database,
+                    Authority = SettingsWrapper.AADAuthority,
+                    ApplicationKey = aadClientKey,
+                    ApplicationClientId = aadClientId
+                };
+            }
+
+            // App SNI auth
+            if (!string.IsNullOrWhiteSpace(aadClientId) && !string.IsNullOrWhiteSpace(certificateThumbprint))
+            {
+                return new KustoConnectionStringBuilder(cluster)
+                {
+                    InitialCatalog = database,
+                }.WithAadApplicationCertificateAuthentication(
+                    aadClientId,
+                    CertificateStore.GetCertificate(certificateThumbprint),
+                    SettingsWrapper.AADAuthority,
+                    true);
+            }
+
+            throw new Exception("Could not determine how to create a connection string from provided parameters.");
         }
 
         /// <summary>
-        /// Allow users to specify cluster.eastus2, cluster.eastus2.kusto.windows.net, or https://cluster.eastus2.kusto.windows.net 
+        /// Allow users to specify cluster.eastus2, cluster.eastus2.kusto.windows.net, or https://cluster.eastus2.kusto.windows.net
         /// </summary>
         /// <param name="cluster">Input cluster name</param>
         /// <returns>Normalized cluster name e.g. https://cluster.eastus2.kusto.windows.net</returns>

--- a/SyncKusto/MainForm.Designer.cs
+++ b/SyncKusto/MainForm.Designer.cs
@@ -102,7 +102,7 @@ namespace SyncKusto
             this.grpComparison.Controls.Add(this.rtbSourceText);
             this.grpComparison.Controls.Add(this.label1);
             this.grpComparison.Controls.Add(this.tvComparison);
-            this.grpComparison.Location = new System.Drawing.Point(12, 298);
+            this.grpComparison.Location = new System.Drawing.Point(12, 270);
             this.grpComparison.Name = "grpComparison";
             this.grpComparison.Size = new System.Drawing.Size(615, 535);
             this.grpComparison.TabIndex = 3;
@@ -156,7 +156,7 @@ namespace SyncKusto
             // 
             this.spcTargetHolder.Location = new System.Drawing.Point(326, 29);
             this.spcTargetHolder.Name = "spcTargetHolder";
-            this.spcTargetHolder.Size = new System.Drawing.Size(306, 264);
+            this.spcTargetHolder.Size = new System.Drawing.Size(306, 235);
             this.spcTargetHolder.TabIndex = 5;
             this.spcTargetHolder.Title = "Target Schema";
             this.spcTargetHolder.Visible = true;
@@ -173,9 +173,9 @@ namespace SyncKusto
             // 
             // spcSourceHolder
             // 
-            this.spcSourceHolder.Location = new System.Drawing.Point(18, 28);
+            this.spcSourceHolder.Location = new System.Drawing.Point(12, 28);
             this.spcSourceHolder.Name = "spcSourceHolder";
-            this.spcSourceHolder.Size = new System.Drawing.Size(306, 264);
+            this.spcSourceHolder.Size = new System.Drawing.Size(306, 230);
             this.spcSourceHolder.TabIndex = 4;
             this.spcSourceHolder.Title = "Source Schema";
             this.spcSourceHolder.Visible = true;
@@ -194,7 +194,7 @@ namespace SyncKusto
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(639, 845);
+            this.ClientSize = new System.Drawing.Size(639, 815);
             this.Controls.Add(this.label2);
             //this.Controls.Add(this.spcTargetHolder);
             //this.Controls.Add(this.spcSourceHolder);
@@ -205,7 +205,7 @@ namespace SyncKusto
             this.Controls.Add(this.grpComparison);
             this.Controls.Add(this.toolStrip1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MinimumSize = new System.Drawing.Size(655, 822);
+            this.MinimumSize = new System.Drawing.Size(655, 815);
             this.Name = "MainForm";
             this.Text = "SyncKusto";
             this.toolStrip1.ResumeLayout(false);

--- a/SyncKusto/MainForm.Designer.cs
+++ b/SyncKusto/MainForm.Designer.cs
@@ -150,7 +150,7 @@ namespace SyncKusto
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(81, 13);
             this.label2.TabIndex = 6;
-            this.label2.Text = "Build 20240208";
+            this.label2.Text = "Build 20240419";
             // 
             // spcTargetHolder
             // 

--- a/SyncKusto/SchemaPickerControl.Designer.cs
+++ b/SyncKusto/SchemaPickerControl.Designer.cs
@@ -42,8 +42,6 @@ namespace SyncKusto
             this.lblAppKey = new System.Windows.Forms.Label();
             this.txtAppId = new System.Windows.Forms.TextBox();
             this.lblAppId = new System.Windows.Forms.Label();
-            this.rbApplication = new System.Windows.Forms.RadioButton();
-            this.rbFederated = new System.Windows.Forms.RadioButton();
             this.txtDatabase = new System.Windows.Forms.TextBox();
             this.lblDatabase = new System.Windows.Forms.Label();
             this.txtCluster = new System.Windows.Forms.TextBox();
@@ -54,6 +52,7 @@ namespace SyncKusto
             this.btnChooseDirectory = new System.Windows.Forms.Button();
             this.rbKusto = new System.Windows.Forms.RadioButton();
             this.rbFilePath = new System.Windows.Forms.RadioButton();
+            this.cmbAuthentication = new System.Windows.Forms.ComboBox();
             this.grpSourceSchema.SuspendLayout();
             this.pnlKusto.SuspendLayout();
             this.grpAuthentication.SuspendLayout();
@@ -68,9 +67,11 @@ namespace SyncKusto
             this.grpSourceSchema.Controls.Add(this.pnlFilePath);
             this.grpSourceSchema.Controls.Add(this.rbKusto);
             this.grpSourceSchema.Controls.Add(this.rbFilePath);
-            this.grpSourceSchema.Location = new System.Drawing.Point(3, 3);
+            this.grpSourceSchema.Location = new System.Drawing.Point(4, 5);
+            this.grpSourceSchema.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpSourceSchema.Name = "grpSourceSchema";
-            this.grpSourceSchema.Size = new System.Drawing.Size(297, 259);
+            this.grpSourceSchema.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpSourceSchema.Size = new System.Drawing.Size(446, 398);
             this.grpSourceSchema.TabIndex = 1;
             this.grpSourceSchema.TabStop = false;
             this.grpSourceSchema.Text = "Source Schema";
@@ -78,10 +79,9 @@ namespace SyncKusto
             // txtOperationProgress
             // 
             this.txtOperationProgress.AutoSize = true;
-            this.txtOperationProgress.Location = new System.Drawing.Point(11, 239);
-            this.txtOperationProgress.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.txtOperationProgress.Location = new System.Drawing.Point(16, 368);
             this.txtOperationProgress.Name = "txtOperationProgress";
-            this.txtOperationProgress.Size = new System.Drawing.Size(0, 13);
+            this.txtOperationProgress.Size = new System.Drawing.Size(0, 20);
             this.txtOperationProgress.TabIndex = 21;
             // 
             // pnlKusto
@@ -91,22 +91,25 @@ namespace SyncKusto
             this.pnlKusto.Controls.Add(this.lblDatabase);
             this.pnlKusto.Controls.Add(this.txtCluster);
             this.pnlKusto.Controls.Add(this.lblCluster);
-            this.pnlKusto.Location = new System.Drawing.Point(6, 43);
+            this.pnlKusto.Location = new System.Drawing.Point(9, 66);
+            this.pnlKusto.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.pnlKusto.Name = "pnlKusto";
-            this.pnlKusto.Size = new System.Drawing.Size(284, 201);
+            this.pnlKusto.Size = new System.Drawing.Size(426, 309);
             this.pnlKusto.TabIndex = 5;
             // 
             // grpAuthentication
             // 
+            this.grpAuthentication.Controls.Add(this.cmbAuthentication);
             this.grpAuthentication.Controls.Add(this.pnlApplicationAuthentication);
-            this.grpAuthentication.Controls.Add(this.rbApplication);
-            this.grpAuthentication.Controls.Add(this.rbFederated);
-            this.grpAuthentication.Location = new System.Drawing.Point(7, 56);
+            this.grpAuthentication.Location = new System.Drawing.Point(10, 86);
+            this.grpAuthentication.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpAuthentication.Name = "grpAuthentication";
-            this.grpAuthentication.Size = new System.Drawing.Size(270, 135);
+            this.grpAuthentication.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpAuthentication.Size = new System.Drawing.Size(405, 208);
             this.grpAuthentication.TabIndex = 4;
             this.grpAuthentication.TabStop = false;
-            this.grpAuthentication.Text = "Authentication";
+            this.grpAuthentication.Text = "Authentication Mode";
+            this.grpAuthentication.UseCompatibleTextRendering = true;
             // 
             // pnlApplicationAuthentication
             // 
@@ -114,97 +117,83 @@ namespace SyncKusto
             this.pnlApplicationAuthentication.Controls.Add(this.lblAppKey);
             this.pnlApplicationAuthentication.Controls.Add(this.txtAppId);
             this.pnlApplicationAuthentication.Controls.Add(this.lblAppId);
-            this.pnlApplicationAuthentication.Location = new System.Drawing.Point(25, 66);
+            this.pnlApplicationAuthentication.Location = new System.Drawing.Point(8, 63);
+            this.pnlApplicationAuthentication.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.pnlApplicationAuthentication.Name = "pnlApplicationAuthentication";
-            this.pnlApplicationAuthentication.Size = new System.Drawing.Size(239, 58);
+            this.pnlApplicationAuthentication.Size = new System.Drawing.Size(388, 89);
             this.pnlApplicationAuthentication.TabIndex = 2;
             this.pnlApplicationAuthentication.Visible = false;
             // 
             // txtAppKey
             // 
-            this.txtAppKey.Location = new System.Drawing.Point(64, 29);
+            this.txtAppKey.Location = new System.Drawing.Point(96, 48);
+            this.txtAppKey.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtAppKey.Name = "txtAppKey";
             this.txtAppKey.PasswordChar = '*';
-            this.txtAppKey.Size = new System.Drawing.Size(149, 20);
+            this.txtAppKey.Size = new System.Drawing.Size(288, 26);
             this.txtAppKey.TabIndex = 7;
             // 
             // lblAppKey
             // 
             this.lblAppKey.AutoSize = true;
-            this.lblAppKey.Location = new System.Drawing.Point(2, 33);
+            this.lblAppKey.Location = new System.Drawing.Point(3, 51);
+            this.lblAppKey.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblAppKey.Name = "lblAppKey";
-            this.lblAppKey.Size = new System.Drawing.Size(50, 13);
+            this.lblAppKey.Size = new System.Drawing.Size(72, 20);
             this.lblAppKey.TabIndex = 6;
             this.lblAppKey.Text = "App Key:";
             // 
             // txtAppId
             // 
-            this.txtAppId.Location = new System.Drawing.Point(64, 3);
+            this.txtAppId.Location = new System.Drawing.Point(96, 8);
+            this.txtAppId.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtAppId.Name = "txtAppId";
-            this.txtAppId.Size = new System.Drawing.Size(149, 20);
+            this.txtAppId.Size = new System.Drawing.Size(288, 26);
             this.txtAppId.TabIndex = 5;
             // 
             // lblAppId
             // 
             this.lblAppId.AutoSize = true;
-            this.lblAppId.Location = new System.Drawing.Point(2, 7);
+            this.lblAppId.Location = new System.Drawing.Point(3, 11);
+            this.lblAppId.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblAppId.Name = "lblAppId";
-            this.lblAppId.Size = new System.Drawing.Size(41, 13);
+            this.lblAppId.Size = new System.Drawing.Size(60, 20);
             this.lblAppId.TabIndex = 4;
             this.lblAppId.Text = "App Id:";
             // 
-            // rbApplication
-            // 
-            this.rbApplication.AutoSize = true;
-            this.rbApplication.Location = new System.Drawing.Point(7, 44);
-            this.rbApplication.Name = "rbApplication";
-            this.rbApplication.Size = new System.Drawing.Size(173, 17);
-            this.rbApplication.TabIndex = 1;
-            this.rbApplication.Text = "AAD Application Authentication";
-            this.rbApplication.UseVisualStyleBackColor = true;
-            this.rbApplication.CheckedChanged += new System.EventHandler(this.rbApplication_CheckedChanged);
-            // 
-            // rbFederated
-            // 
-            this.rbFederated.AutoSize = true;
-            this.rbFederated.Checked = true;
-            this.rbFederated.Location = new System.Drawing.Point(7, 20);
-            this.rbFederated.Name = "rbFederated";
-            this.rbFederated.Size = new System.Drawing.Size(169, 17);
-            this.rbFederated.TabIndex = 0;
-            this.rbFederated.TabStop = true;
-            this.rbFederated.Text = "AAD Federated Authentication";
-            this.rbFederated.UseVisualStyleBackColor = true;
-            // 
             // txtDatabase
             // 
-            this.txtDatabase.Location = new System.Drawing.Point(66, 26);
+            this.txtDatabase.Location = new System.Drawing.Point(99, 44);
+            this.txtDatabase.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtDatabase.Name = "txtDatabase";
-            this.txtDatabase.Size = new System.Drawing.Size(211, 20);
+            this.txtDatabase.Size = new System.Drawing.Size(314, 26);
             this.txtDatabase.TabIndex = 3;
             // 
             // lblDatabase
             // 
             this.lblDatabase.AutoSize = true;
-            this.lblDatabase.Location = new System.Drawing.Point(4, 30);
+            this.lblDatabase.Location = new System.Drawing.Point(6, 46);
+            this.lblDatabase.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblDatabase.Name = "lblDatabase";
-            this.lblDatabase.Size = new System.Drawing.Size(56, 13);
+            this.lblDatabase.Size = new System.Drawing.Size(83, 20);
             this.lblDatabase.TabIndex = 2;
             this.lblDatabase.Text = "Database:";
             // 
             // txtCluster
             // 
-            this.txtCluster.Location = new System.Drawing.Point(66, 0);
+            this.txtCluster.Location = new System.Drawing.Point(99, 4);
+            this.txtCluster.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtCluster.Name = "txtCluster";
-            this.txtCluster.Size = new System.Drawing.Size(211, 20);
+            this.txtCluster.Size = new System.Drawing.Size(314, 26);
             this.txtCluster.TabIndex = 1;
             // 
             // lblCluster
             // 
             this.lblCluster.AutoSize = true;
-            this.lblCluster.Location = new System.Drawing.Point(4, 4);
+            this.lblCluster.Location = new System.Drawing.Point(6, 6);
+            this.lblCluster.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblCluster.Name = "lblCluster";
-            this.lblCluster.Size = new System.Drawing.Size(42, 13);
+            this.lblCluster.Size = new System.Drawing.Size(63, 20);
             this.lblCluster.TabIndex = 0;
             this.lblCluster.Text = "Cluster:";
             // 
@@ -213,34 +202,38 @@ namespace SyncKusto
             this.pnlFilePath.Controls.Add(this.lblExample);
             this.pnlFilePath.Controls.Add(this.txtFilePath);
             this.pnlFilePath.Controls.Add(this.btnChooseDirectory);
-            this.pnlFilePath.Location = new System.Drawing.Point(7, 43);
+            this.pnlFilePath.Location = new System.Drawing.Point(10, 66);
+            this.pnlFilePath.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.pnlFilePath.Name = "pnlFilePath";
-            this.pnlFilePath.Size = new System.Drawing.Size(284, 84);
+            this.pnlFilePath.Size = new System.Drawing.Size(426, 129);
             this.pnlFilePath.TabIndex = 4;
             // 
             // lblExample
             // 
             this.lblExample.AutoSize = true;
             this.lblExample.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
-            this.lblExample.Location = new System.Drawing.Point(4, 30);
+            this.lblExample.Location = new System.Drawing.Point(6, 46);
+            this.lblExample.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblExample.Name = "lblExample";
-            this.lblExample.Size = new System.Drawing.Size(278, 39);
+            this.lblExample.Size = new System.Drawing.Size(414, 60);
             this.lblExample.TabIndex = 4;
             this.lblExample.Text = "Choose the directory that is the parent of the \"Functions\" \r\ndirectory. \r\nExample" +
     ": c:\\git\\myrepo\\mycluster\\mydatabase";
             // 
             // txtFilePath
             // 
-            this.txtFilePath.Location = new System.Drawing.Point(3, 3);
+            this.txtFilePath.Location = new System.Drawing.Point(4, 5);
+            this.txtFilePath.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtFilePath.Name = "txtFilePath";
-            this.txtFilePath.Size = new System.Drawing.Size(242, 20);
+            this.txtFilePath.Size = new System.Drawing.Size(361, 26);
             this.txtFilePath.TabIndex = 2;
             // 
             // btnChooseDirectory
             // 
-            this.btnChooseDirectory.Location = new System.Drawing.Point(251, 3);
+            this.btnChooseDirectory.Location = new System.Drawing.Point(376, 5);
+            this.btnChooseDirectory.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnChooseDirectory.Name = "btnChooseDirectory";
-            this.btnChooseDirectory.Size = new System.Drawing.Size(26, 20);
+            this.btnChooseDirectory.Size = new System.Drawing.Size(39, 31);
             this.btnChooseDirectory.TabIndex = 3;
             this.btnChooseDirectory.Text = "...";
             this.btnChooseDirectory.UseVisualStyleBackColor = true;
@@ -249,9 +242,10 @@ namespace SyncKusto
             // rbKusto
             // 
             this.rbKusto.AutoSize = true;
-            this.rbKusto.Location = new System.Drawing.Point(78, 19);
+            this.rbKusto.Location = new System.Drawing.Point(117, 29);
+            this.rbKusto.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.rbKusto.Name = "rbKusto";
-            this.rbKusto.Size = new System.Drawing.Size(52, 17);
+            this.rbKusto.Size = new System.Drawing.Size(75, 24);
             this.rbKusto.TabIndex = 1;
             this.rbKusto.Text = "Kusto";
             this.rbKusto.UseVisualStyleBackColor = true;
@@ -261,28 +255,41 @@ namespace SyncKusto
             // 
             this.rbFilePath.AutoSize = true;
             this.rbFilePath.Checked = true;
-            this.rbFilePath.Location = new System.Drawing.Point(6, 19);
+            this.rbFilePath.Location = new System.Drawing.Point(9, 29);
+            this.rbFilePath.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.rbFilePath.Name = "rbFilePath";
-            this.rbFilePath.Size = new System.Drawing.Size(66, 17);
+            this.rbFilePath.Size = new System.Drawing.Size(96, 24);
             this.rbFilePath.TabIndex = 0;
             this.rbFilePath.TabStop = true;
             this.rbFilePath.Text = "File Path";
             this.rbFilePath.UseVisualStyleBackColor = true;
             this.rbFilePath.CheckedChanged += new System.EventHandler(this.rbFilePath_CheckedChanged);
             // 
+            // cmbAuthentication
+            // 
+            this.cmbAuthentication.FormattingEnabled = true;
+            this.cmbAuthentication.Items.AddRange(new object[] {
+            "Entra User",
+            "Entra App (Key)"});
+            this.cmbAuthentication.Location = new System.Drawing.Point(7, 27);
+            this.cmbAuthentication.Name = "cmbAuthentication";
+            this.cmbAuthentication.Size = new System.Drawing.Size(389, 28);
+            this.cmbAuthentication.TabIndex = 3;
+            this.cmbAuthentication.SelectedValueChanged += new System.EventHandler(this.cmbAuthentication_SelectedValueChanged);
+            // 
             // SchemaPickerControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.grpSourceSchema);
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.Name = "SchemaPickerControl";
-            this.Size = new System.Drawing.Size(306, 261);
+            this.Size = new System.Drawing.Size(459, 402);
             this.grpSourceSchema.ResumeLayout(false);
             this.grpSourceSchema.PerformLayout();
             this.pnlKusto.ResumeLayout(false);
             this.pnlKusto.PerformLayout();
             this.grpAuthentication.ResumeLayout(false);
-            this.grpAuthentication.PerformLayout();
             this.pnlApplicationAuthentication.ResumeLayout(false);
             this.pnlApplicationAuthentication.PerformLayout();
             this.pnlFilePath.ResumeLayout(false);
@@ -305,8 +312,6 @@ namespace SyncKusto
         private System.Windows.Forms.TextBox txtCluster;
         private System.Windows.Forms.Label lblCluster;
         private System.Windows.Forms.GroupBox grpAuthentication;
-        private System.Windows.Forms.RadioButton rbApplication;
-        private System.Windows.Forms.RadioButton rbFederated;
         private System.Windows.Forms.Panel pnlApplicationAuthentication;
         private System.Windows.Forms.TextBox txtAppKey;
         private System.Windows.Forms.Label lblAppKey;
@@ -314,5 +319,6 @@ namespace SyncKusto
         private System.Windows.Forms.Label lblAppId;
         private System.Windows.Forms.Label lblExample;
         private System.Windows.Forms.Label txtOperationProgress;
+        private System.Windows.Forms.ComboBox cmbAuthentication;
     }
 }

--- a/SyncKusto/SchemaPickerControl.Designer.cs
+++ b/SyncKusto/SchemaPickerControl.Designer.cs
@@ -135,9 +135,9 @@ namespace SyncKusto
             // 
             // btnCertificate
             // 
-            this.btnCertificate.Location = new System.Drawing.Point(355, 45);
+            this.btnCertificate.Location = new System.Drawing.Point(349, 48);
             this.btnCertificate.Name = "btnCertificate";
-            this.btnCertificate.Size = new System.Drawing.Size(32, 32);
+            this.btnCertificate.Size = new System.Drawing.Size(39, 31);
             this.btnCertificate.TabIndex = 8;
             this.btnCertificate.Text = "...";
             this.btnCertificate.UseVisualStyleBackColor = true;
@@ -148,7 +148,7 @@ namespace SyncKusto
             this.txtCertificate.Location = new System.Drawing.Point(180, 48);
             this.txtCertificate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtCertificate.Name = "txtCertificate";
-            this.txtCertificate.Size = new System.Drawing.Size(167, 26);
+            this.txtCertificate.Size = new System.Drawing.Size(160, 26);
             this.txtCertificate.TabIndex = 7;
             // 
             // lblCertificate

--- a/SyncKusto/SchemaPickerControl.Designer.cs
+++ b/SyncKusto/SchemaPickerControl.Designer.cs
@@ -134,7 +134,7 @@ namespace SyncKusto
             this.pnlApplicationAuthentication.Controls.Add(this.lblAppKey);
             this.pnlApplicationAuthentication.Controls.Add(this.txtAppId);
             this.pnlApplicationAuthentication.Controls.Add(this.lblAppId);
-            this.pnlApplicationAuthentication.Location = new System.Drawing.Point(166, 71);
+            this.pnlApplicationAuthentication.Location = new System.Drawing.Point(9, 71);
             this.pnlApplicationAuthentication.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.pnlApplicationAuthentication.Name = "pnlApplicationAuthentication";
             this.pnlApplicationAuthentication.Size = new System.Drawing.Size(388, 89);
@@ -289,7 +289,7 @@ namespace SyncKusto
             this.pnlApplicationSniAuthentication.Controls.Add(this.lblCertificate);
             this.pnlApplicationSniAuthentication.Controls.Add(this.txtAppIdSni);
             this.pnlApplicationSniAuthentication.Controls.Add(this.lblAppIdSni);
-            this.pnlApplicationSniAuthentication.Location = new System.Drawing.Point(9, 107);
+            this.pnlApplicationSniAuthentication.Location = new System.Drawing.Point(9, 71);
             this.pnlApplicationSniAuthentication.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.pnlApplicationSniAuthentication.Name = "pnlApplicationSniAuthentication";
             this.pnlApplicationSniAuthentication.Size = new System.Drawing.Size(388, 89);
@@ -298,11 +298,10 @@ namespace SyncKusto
             // 
             // txtCertificate
             // 
-            this.txtCertificate.Location = new System.Drawing.Point(96, 48);
+            this.txtCertificate.Location = new System.Drawing.Point(180, 48);
             this.txtCertificate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtCertificate.Name = "txtCertificate";
-            this.txtCertificate.PasswordChar = '*';
-            this.txtCertificate.Size = new System.Drawing.Size(251, 26);
+            this.txtCertificate.Size = new System.Drawing.Size(167, 26);
             this.txtCertificate.TabIndex = 7;
             // 
             // lblCertificate
@@ -311,16 +310,16 @@ namespace SyncKusto
             this.lblCertificate.Location = new System.Drawing.Point(3, 51);
             this.lblCertificate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblCertificate.Name = "lblCertificate";
-            this.lblCertificate.Size = new System.Drawing.Size(72, 20);
+            this.lblCertificate.Size = new System.Drawing.Size(169, 20);
             this.lblCertificate.TabIndex = 6;
-            this.lblCertificate.Text = "App Key:";
+            this.lblCertificate.Text = "Certificate Thumbprint:";
             // 
             // txtAppIdSni
             // 
-            this.txtAppIdSni.Location = new System.Drawing.Point(96, 8);
+            this.txtAppIdSni.Location = new System.Drawing.Point(180, 8);
             this.txtAppIdSni.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtAppIdSni.Name = "txtAppIdSni";
-            this.txtAppIdSni.Size = new System.Drawing.Size(288, 26);
+            this.txtAppIdSni.Size = new System.Drawing.Size(204, 26);
             this.txtAppIdSni.TabIndex = 5;
             // 
             // lblAppIdSni
@@ -341,6 +340,7 @@ namespace SyncKusto
             this.btnCertificate.TabIndex = 8;
             this.btnCertificate.Text = "...";
             this.btnCertificate.UseVisualStyleBackColor = true;
+            this.btnCertificate.Click += new System.EventHandler(this.btnCertificate_Click);
             // 
             // SchemaPickerControl
             // 

--- a/SyncKusto/SchemaPickerControl.Designer.cs
+++ b/SyncKusto/SchemaPickerControl.Designer.cs
@@ -37,6 +37,7 @@ namespace SyncKusto
             this.txtOperationProgress = new System.Windows.Forms.Label();
             this.pnlKusto = new System.Windows.Forms.Panel();
             this.grpAuthentication = new System.Windows.Forms.GroupBox();
+            this.cmbAuthentication = new System.Windows.Forms.ComboBox();
             this.pnlApplicationAuthentication = new System.Windows.Forms.Panel();
             this.txtAppKey = new System.Windows.Forms.TextBox();
             this.lblAppKey = new System.Windows.Forms.Label();
@@ -52,12 +53,18 @@ namespace SyncKusto
             this.btnChooseDirectory = new System.Windows.Forms.Button();
             this.rbKusto = new System.Windows.Forms.RadioButton();
             this.rbFilePath = new System.Windows.Forms.RadioButton();
-            this.cmbAuthentication = new System.Windows.Forms.ComboBox();
+            this.pnlApplicationSniAuthentication = new System.Windows.Forms.Panel();
+            this.txtCertificate = new System.Windows.Forms.TextBox();
+            this.lblCertificate = new System.Windows.Forms.Label();
+            this.txtAppIdSni = new System.Windows.Forms.TextBox();
+            this.lblAppIdSni = new System.Windows.Forms.Label();
+            this.btnCertificate = new System.Windows.Forms.Button();
             this.grpSourceSchema.SuspendLayout();
             this.pnlKusto.SuspendLayout();
             this.grpAuthentication.SuspendLayout();
             this.pnlApplicationAuthentication.SuspendLayout();
             this.pnlFilePath.SuspendLayout();
+            this.pnlApplicationSniAuthentication.SuspendLayout();
             this.SuspendLayout();
             // 
             // grpSourceSchema
@@ -99,6 +106,7 @@ namespace SyncKusto
             // 
             // grpAuthentication
             // 
+            this.grpAuthentication.Controls.Add(this.pnlApplicationSniAuthentication);
             this.grpAuthentication.Controls.Add(this.cmbAuthentication);
             this.grpAuthentication.Controls.Add(this.pnlApplicationAuthentication);
             this.grpAuthentication.Location = new System.Drawing.Point(10, 86);
@@ -111,13 +119,22 @@ namespace SyncKusto
             this.grpAuthentication.Text = "Authentication Mode";
             this.grpAuthentication.UseCompatibleTextRendering = true;
             // 
+            // cmbAuthentication
+            // 
+            this.cmbAuthentication.FormattingEnabled = true;
+            this.cmbAuthentication.Location = new System.Drawing.Point(7, 27);
+            this.cmbAuthentication.Name = "cmbAuthentication";
+            this.cmbAuthentication.Size = new System.Drawing.Size(389, 28);
+            this.cmbAuthentication.TabIndex = 3;
+            this.cmbAuthentication.SelectedValueChanged += new System.EventHandler(this.cmbAuthentication_SelectedValueChanged);
+            // 
             // pnlApplicationAuthentication
             // 
             this.pnlApplicationAuthentication.Controls.Add(this.txtAppKey);
             this.pnlApplicationAuthentication.Controls.Add(this.lblAppKey);
             this.pnlApplicationAuthentication.Controls.Add(this.txtAppId);
             this.pnlApplicationAuthentication.Controls.Add(this.lblAppId);
-            this.pnlApplicationAuthentication.Location = new System.Drawing.Point(8, 63);
+            this.pnlApplicationAuthentication.Location = new System.Drawing.Point(166, 71);
             this.pnlApplicationAuthentication.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.pnlApplicationAuthentication.Name = "pnlApplicationAuthentication";
             this.pnlApplicationAuthentication.Size = new System.Drawing.Size(388, 89);
@@ -265,17 +282,65 @@ namespace SyncKusto
             this.rbFilePath.UseVisualStyleBackColor = true;
             this.rbFilePath.CheckedChanged += new System.EventHandler(this.rbFilePath_CheckedChanged);
             // 
-            // cmbAuthentication
+            // pnlApplicationSniAuthentication
             // 
-            this.cmbAuthentication.FormattingEnabled = true;
-            this.cmbAuthentication.Items.AddRange(new object[] {
-            "Entra User",
-            "Entra App (Key)"});
-            this.cmbAuthentication.Location = new System.Drawing.Point(7, 27);
-            this.cmbAuthentication.Name = "cmbAuthentication";
-            this.cmbAuthentication.Size = new System.Drawing.Size(389, 28);
-            this.cmbAuthentication.TabIndex = 3;
-            this.cmbAuthentication.SelectedValueChanged += new System.EventHandler(this.cmbAuthentication_SelectedValueChanged);
+            this.pnlApplicationSniAuthentication.Controls.Add(this.btnCertificate);
+            this.pnlApplicationSniAuthentication.Controls.Add(this.txtCertificate);
+            this.pnlApplicationSniAuthentication.Controls.Add(this.lblCertificate);
+            this.pnlApplicationSniAuthentication.Controls.Add(this.txtAppIdSni);
+            this.pnlApplicationSniAuthentication.Controls.Add(this.lblAppIdSni);
+            this.pnlApplicationSniAuthentication.Location = new System.Drawing.Point(9, 107);
+            this.pnlApplicationSniAuthentication.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.pnlApplicationSniAuthentication.Name = "pnlApplicationSniAuthentication";
+            this.pnlApplicationSniAuthentication.Size = new System.Drawing.Size(388, 89);
+            this.pnlApplicationSniAuthentication.TabIndex = 4;
+            this.pnlApplicationSniAuthentication.Visible = false;
+            // 
+            // txtCertificate
+            // 
+            this.txtCertificate.Location = new System.Drawing.Point(96, 48);
+            this.txtCertificate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.txtCertificate.Name = "txtCertificate";
+            this.txtCertificate.PasswordChar = '*';
+            this.txtCertificate.Size = new System.Drawing.Size(251, 26);
+            this.txtCertificate.TabIndex = 7;
+            // 
+            // lblCertificate
+            // 
+            this.lblCertificate.AutoSize = true;
+            this.lblCertificate.Location = new System.Drawing.Point(3, 51);
+            this.lblCertificate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblCertificate.Name = "lblCertificate";
+            this.lblCertificate.Size = new System.Drawing.Size(72, 20);
+            this.lblCertificate.TabIndex = 6;
+            this.lblCertificate.Text = "App Key:";
+            // 
+            // txtAppIdSni
+            // 
+            this.txtAppIdSni.Location = new System.Drawing.Point(96, 8);
+            this.txtAppIdSni.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.txtAppIdSni.Name = "txtAppIdSni";
+            this.txtAppIdSni.Size = new System.Drawing.Size(288, 26);
+            this.txtAppIdSni.TabIndex = 5;
+            // 
+            // lblAppIdSni
+            // 
+            this.lblAppIdSni.AutoSize = true;
+            this.lblAppIdSni.Location = new System.Drawing.Point(3, 11);
+            this.lblAppIdSni.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblAppIdSni.Name = "lblAppIdSni";
+            this.lblAppIdSni.Size = new System.Drawing.Size(60, 20);
+            this.lblAppIdSni.TabIndex = 4;
+            this.lblAppIdSni.Text = "App Id:";
+            // 
+            // btnCertificate
+            // 
+            this.btnCertificate.Location = new System.Drawing.Point(355, 47);
+            this.btnCertificate.Name = "btnCertificate";
+            this.btnCertificate.Size = new System.Drawing.Size(32, 27);
+            this.btnCertificate.TabIndex = 8;
+            this.btnCertificate.Text = "...";
+            this.btnCertificate.UseVisualStyleBackColor = true;
             // 
             // SchemaPickerControl
             // 
@@ -294,6 +359,8 @@ namespace SyncKusto
             this.pnlApplicationAuthentication.PerformLayout();
             this.pnlFilePath.ResumeLayout(false);
             this.pnlFilePath.PerformLayout();
+            this.pnlApplicationSniAuthentication.ResumeLayout(false);
+            this.pnlApplicationSniAuthentication.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -320,5 +387,11 @@ namespace SyncKusto
         private System.Windows.Forms.Label lblExample;
         private System.Windows.Forms.Label txtOperationProgress;
         private System.Windows.Forms.ComboBox cmbAuthentication;
+        private System.Windows.Forms.Panel pnlApplicationSniAuthentication;
+        private System.Windows.Forms.Button btnCertificate;
+        private System.Windows.Forms.TextBox txtCertificate;
+        private System.Windows.Forms.Label lblCertificate;
+        private System.Windows.Forms.TextBox txtAppIdSni;
+        private System.Windows.Forms.Label lblAppIdSni;
     }
 }

--- a/SyncKusto/SchemaPickerControl.Designer.cs
+++ b/SyncKusto/SchemaPickerControl.Designer.cs
@@ -37,6 +37,12 @@ namespace SyncKusto
             this.txtOperationProgress = new System.Windows.Forms.Label();
             this.pnlKusto = new System.Windows.Forms.Panel();
             this.grpAuthentication = new System.Windows.Forms.GroupBox();
+            this.pnlApplicationSniAuthentication = new System.Windows.Forms.Panel();
+            this.btnCertificate = new System.Windows.Forms.Button();
+            this.txtCertificate = new System.Windows.Forms.TextBox();
+            this.lblCertificate = new System.Windows.Forms.Label();
+            this.txtAppIdSni = new System.Windows.Forms.TextBox();
+            this.lblAppIdSni = new System.Windows.Forms.Label();
             this.cmbAuthentication = new System.Windows.Forms.ComboBox();
             this.pnlApplicationAuthentication = new System.Windows.Forms.Panel();
             this.txtAppKey = new System.Windows.Forms.TextBox();
@@ -53,18 +59,12 @@ namespace SyncKusto
             this.btnChooseDirectory = new System.Windows.Forms.Button();
             this.rbKusto = new System.Windows.Forms.RadioButton();
             this.rbFilePath = new System.Windows.Forms.RadioButton();
-            this.pnlApplicationSniAuthentication = new System.Windows.Forms.Panel();
-            this.txtCertificate = new System.Windows.Forms.TextBox();
-            this.lblCertificate = new System.Windows.Forms.Label();
-            this.txtAppIdSni = new System.Windows.Forms.TextBox();
-            this.lblAppIdSni = new System.Windows.Forms.Label();
-            this.btnCertificate = new System.Windows.Forms.Button();
             this.grpSourceSchema.SuspendLayout();
             this.pnlKusto.SuspendLayout();
             this.grpAuthentication.SuspendLayout();
+            this.pnlApplicationSniAuthentication.SuspendLayout();
             this.pnlApplicationAuthentication.SuspendLayout();
             this.pnlFilePath.SuspendLayout();
-            this.pnlApplicationSniAuthentication.SuspendLayout();
             this.SuspendLayout();
             // 
             // grpSourceSchema
@@ -78,7 +78,7 @@ namespace SyncKusto
             this.grpSourceSchema.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpSourceSchema.Name = "grpSourceSchema";
             this.grpSourceSchema.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.grpSourceSchema.Size = new System.Drawing.Size(446, 398);
+            this.grpSourceSchema.Size = new System.Drawing.Size(446, 348);
             this.grpSourceSchema.TabIndex = 1;
             this.grpSourceSchema.TabStop = false;
             this.grpSourceSchema.Text = "Source Schema";
@@ -101,7 +101,7 @@ namespace SyncKusto
             this.pnlKusto.Location = new System.Drawing.Point(9, 66);
             this.pnlKusto.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.pnlKusto.Name = "pnlKusto";
-            this.pnlKusto.Size = new System.Drawing.Size(426, 309);
+            this.pnlKusto.Size = new System.Drawing.Size(426, 265);
             this.pnlKusto.TabIndex = 5;
             // 
             // grpAuthentication
@@ -113,11 +113,71 @@ namespace SyncKusto
             this.grpAuthentication.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpAuthentication.Name = "grpAuthentication";
             this.grpAuthentication.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.grpAuthentication.Size = new System.Drawing.Size(405, 208);
+            this.grpAuthentication.Size = new System.Drawing.Size(405, 172);
             this.grpAuthentication.TabIndex = 4;
             this.grpAuthentication.TabStop = false;
             this.grpAuthentication.Text = "Authentication Mode";
             this.grpAuthentication.UseCompatibleTextRendering = true;
+            // 
+            // pnlApplicationSniAuthentication
+            // 
+            this.pnlApplicationSniAuthentication.Controls.Add(this.btnCertificate);
+            this.pnlApplicationSniAuthentication.Controls.Add(this.txtCertificate);
+            this.pnlApplicationSniAuthentication.Controls.Add(this.lblCertificate);
+            this.pnlApplicationSniAuthentication.Controls.Add(this.txtAppIdSni);
+            this.pnlApplicationSniAuthentication.Controls.Add(this.lblAppIdSni);
+            this.pnlApplicationSniAuthentication.Location = new System.Drawing.Point(9, 71);
+            this.pnlApplicationSniAuthentication.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.pnlApplicationSniAuthentication.Name = "pnlApplicationSniAuthentication";
+            this.pnlApplicationSniAuthentication.Size = new System.Drawing.Size(388, 89);
+            this.pnlApplicationSniAuthentication.TabIndex = 4;
+            this.pnlApplicationSniAuthentication.Visible = false;
+            // 
+            // btnCertificate
+            // 
+            this.btnCertificate.Location = new System.Drawing.Point(355, 45);
+            this.btnCertificate.Name = "btnCertificate";
+            this.btnCertificate.Size = new System.Drawing.Size(32, 32);
+            this.btnCertificate.TabIndex = 8;
+            this.btnCertificate.Text = "...";
+            this.btnCertificate.UseVisualStyleBackColor = true;
+            this.btnCertificate.Click += new System.EventHandler(this.btnCertificate_Click);
+            // 
+            // txtCertificate
+            // 
+            this.txtCertificate.Location = new System.Drawing.Point(180, 48);
+            this.txtCertificate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.txtCertificate.Name = "txtCertificate";
+            this.txtCertificate.Size = new System.Drawing.Size(167, 26);
+            this.txtCertificate.TabIndex = 7;
+            // 
+            // lblCertificate
+            // 
+            this.lblCertificate.AutoSize = true;
+            this.lblCertificate.Location = new System.Drawing.Point(3, 51);
+            this.lblCertificate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblCertificate.Name = "lblCertificate";
+            this.lblCertificate.Size = new System.Drawing.Size(169, 20);
+            this.lblCertificate.TabIndex = 6;
+            this.lblCertificate.Text = "Certificate Thumbprint:";
+            // 
+            // txtAppIdSni
+            // 
+            this.txtAppIdSni.Location = new System.Drawing.Point(180, 8);
+            this.txtAppIdSni.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.txtAppIdSni.Name = "txtAppIdSni";
+            this.txtAppIdSni.Size = new System.Drawing.Size(204, 26);
+            this.txtAppIdSni.TabIndex = 5;
+            // 
+            // lblAppIdSni
+            // 
+            this.lblAppIdSni.AutoSize = true;
+            this.lblAppIdSni.Location = new System.Drawing.Point(3, 11);
+            this.lblAppIdSni.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblAppIdSni.Name = "lblAppIdSni";
+            this.lblAppIdSni.Size = new System.Drawing.Size(60, 20);
+            this.lblAppIdSni.TabIndex = 4;
+            this.lblAppIdSni.Text = "App Id:";
             // 
             // cmbAuthentication
             // 
@@ -282,66 +342,6 @@ namespace SyncKusto
             this.rbFilePath.UseVisualStyleBackColor = true;
             this.rbFilePath.CheckedChanged += new System.EventHandler(this.rbFilePath_CheckedChanged);
             // 
-            // pnlApplicationSniAuthentication
-            // 
-            this.pnlApplicationSniAuthentication.Controls.Add(this.btnCertificate);
-            this.pnlApplicationSniAuthentication.Controls.Add(this.txtCertificate);
-            this.pnlApplicationSniAuthentication.Controls.Add(this.lblCertificate);
-            this.pnlApplicationSniAuthentication.Controls.Add(this.txtAppIdSni);
-            this.pnlApplicationSniAuthentication.Controls.Add(this.lblAppIdSni);
-            this.pnlApplicationSniAuthentication.Location = new System.Drawing.Point(9, 71);
-            this.pnlApplicationSniAuthentication.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.pnlApplicationSniAuthentication.Name = "pnlApplicationSniAuthentication";
-            this.pnlApplicationSniAuthentication.Size = new System.Drawing.Size(388, 89);
-            this.pnlApplicationSniAuthentication.TabIndex = 4;
-            this.pnlApplicationSniAuthentication.Visible = false;
-            // 
-            // txtCertificate
-            // 
-            this.txtCertificate.Location = new System.Drawing.Point(180, 48);
-            this.txtCertificate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.txtCertificate.Name = "txtCertificate";
-            this.txtCertificate.Size = new System.Drawing.Size(167, 26);
-            this.txtCertificate.TabIndex = 7;
-            // 
-            // lblCertificate
-            // 
-            this.lblCertificate.AutoSize = true;
-            this.lblCertificate.Location = new System.Drawing.Point(3, 51);
-            this.lblCertificate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblCertificate.Name = "lblCertificate";
-            this.lblCertificate.Size = new System.Drawing.Size(169, 20);
-            this.lblCertificate.TabIndex = 6;
-            this.lblCertificate.Text = "Certificate Thumbprint:";
-            // 
-            // txtAppIdSni
-            // 
-            this.txtAppIdSni.Location = new System.Drawing.Point(180, 8);
-            this.txtAppIdSni.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.txtAppIdSni.Name = "txtAppIdSni";
-            this.txtAppIdSni.Size = new System.Drawing.Size(204, 26);
-            this.txtAppIdSni.TabIndex = 5;
-            // 
-            // lblAppIdSni
-            // 
-            this.lblAppIdSni.AutoSize = true;
-            this.lblAppIdSni.Location = new System.Drawing.Point(3, 11);
-            this.lblAppIdSni.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblAppIdSni.Name = "lblAppIdSni";
-            this.lblAppIdSni.Size = new System.Drawing.Size(60, 20);
-            this.lblAppIdSni.TabIndex = 4;
-            this.lblAppIdSni.Text = "App Id:";
-            // 
-            // btnCertificate
-            // 
-            this.btnCertificate.Location = new System.Drawing.Point(355, 47);
-            this.btnCertificate.Name = "btnCertificate";
-            this.btnCertificate.Size = new System.Drawing.Size(32, 27);
-            this.btnCertificate.TabIndex = 8;
-            this.btnCertificate.Text = "...";
-            this.btnCertificate.UseVisualStyleBackColor = true;
-            this.btnCertificate.Click += new System.EventHandler(this.btnCertificate_Click);
-            // 
             // SchemaPickerControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
@@ -349,18 +349,18 @@ namespace SyncKusto
             this.Controls.Add(this.grpSourceSchema);
             this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.Name = "SchemaPickerControl";
-            this.Size = new System.Drawing.Size(459, 402);
+            this.Size = new System.Drawing.Size(459, 362);
             this.grpSourceSchema.ResumeLayout(false);
             this.grpSourceSchema.PerformLayout();
             this.pnlKusto.ResumeLayout(false);
             this.pnlKusto.PerformLayout();
             this.grpAuthentication.ResumeLayout(false);
+            this.pnlApplicationSniAuthentication.ResumeLayout(false);
+            this.pnlApplicationSniAuthentication.PerformLayout();
             this.pnlApplicationAuthentication.ResumeLayout(false);
             this.pnlApplicationAuthentication.PerformLayout();
             this.pnlFilePath.ResumeLayout(false);
             this.pnlFilePath.PerformLayout();
-            this.pnlApplicationSniAuthentication.ResumeLayout(false);
-            this.pnlApplicationSniAuthentication.PerformLayout();
             this.ResumeLayout(false);
 
         }

--- a/SyncKusto/SchemaPickerControl.cs
+++ b/SyncKusto/SchemaPickerControl.cs
@@ -19,12 +19,22 @@ namespace SyncKusto
 {
     public partial class SchemaPickerControl : UserControl
     {
+        private const string ENTRA_ID_USER = "Microsoft Entra ID User";
+        private const string ENTRA_ID_APP_KEY = "Microsoft Entra ID App (Key)";
+        private const string ENTRA_ID_APP_SNI = "Microsoft Entra ID App (SubjectName/Issuer)";
+
         /// <summary>
         ///     Default constructor to make the Windows Forms designer happy
         /// </summary>
         public SchemaPickerControl()
         {
             InitializeComponent();
+
+            this.cmbAuthentication.Items.AddRange(
+                new object[] {
+                    ENTRA_ID_USER,
+                    ENTRA_ID_APP_KEY,
+                    ENTRA_ID_APP_SNI });
 
             this.cmbAuthentication.SelectedIndex = 0;
         }
@@ -70,11 +80,14 @@ namespace SyncKusto
             {
                 switch (cmbAuthentication.SelectedItem)
                 {
-                    case "Entra User":
+                    case ENTRA_ID_USER:
                         return AuthenticationMode.AadFederated;
 
-                    case "Entra App (Key)":
+                    case ENTRA_ID_APP_KEY:
                         return AuthenticationMode.AadApplication;
+
+                    case ENTRA_ID_APP_SNI:
+                        return AuthenticationMode.AadApplicationSni;
 
                     default:
                         throw new Exception("Unknown authentication type");
@@ -95,6 +108,9 @@ namespace SyncKusto
 
                     case AuthenticationMode.AadApplication:
                         return QueryEngine.GetKustoConnectionStringBuilder(txtCluster.Text, txtDatabase.Text, txtAppId.Text, txtAppKey.Text);
+
+                    case AuthenticationMode.AadApplicationSni:
+                        throw new NotImplementedException("TODO");
 
                     default:
                         throw new Exception("Unknown authentication type");
@@ -260,6 +276,7 @@ namespace SyncKusto
         private void cmbAuthentication_SelectedValueChanged(object sender, EventArgs e)
         {
             pnlApplicationAuthentication.Visible = Authentication == AuthenticationMode.AadApplication;
+            pnlApplicationSniAuthentication.Visible = Authentication == AuthenticationMode.AadApplicationSni;
         }
     }
 }

--- a/SyncKusto/SettingsForm.Designer.cs
+++ b/SyncKusto/SettingsForm.Designer.cs
@@ -62,10 +62,10 @@ namespace SyncKusto
             // btnOk
             // 
             this.btnOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnOk.Location = new System.Drawing.Point(301, 637);
-            this.btnOk.Margin = new System.Windows.Forms.Padding(4);
+            this.btnOk.Location = new System.Drawing.Point(339, 796);
+            this.btnOk.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnOk.Name = "btnOk";
-            this.btnOk.Size = new System.Drawing.Size(100, 28);
+            this.btnOk.Size = new System.Drawing.Size(112, 35);
             this.btnOk.TabIndex = 6;
             this.btnOk.Text = "O&K";
             this.btnOk.UseVisualStyleBackColor = true;
@@ -74,10 +74,10 @@ namespace SyncKusto
             // btnCancel
             // 
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnCancel.Location = new System.Drawing.Point(409, 637);
-            this.btnCancel.Margin = new System.Windows.Forms.Padding(4);
+            this.btnCancel.Location = new System.Drawing.Point(460, 796);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(100, 28);
+            this.btnCancel.Size = new System.Drawing.Size(112, 35);
             this.btnCancel.TabIndex = 7;
             this.btnCancel.Text = "&Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
@@ -89,33 +89,33 @@ namespace SyncKusto
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox1.Controls.Add(this.txtAuthority);
             this.groupBox1.Controls.Add(this.label3);
-            this.groupBox1.Location = new System.Drawing.Point(16, 217);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(4);
+            this.groupBox1.Location = new System.Drawing.Point(18, 271);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Padding = new System.Windows.Forms.Padding(4);
-            this.groupBox1.Size = new System.Drawing.Size(492, 123);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox1.Size = new System.Drawing.Size(554, 154);
             this.groupBox1.TabIndex = 106;
             this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "AAD Authority";
+            this.groupBox1.Text = "Microsoft Entra ID Authority";
             // 
             // txtAuthority
             // 
             this.txtAuthority.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtAuthority.Location = new System.Drawing.Point(8, 91);
-            this.txtAuthority.Margin = new System.Windows.Forms.Padding(4);
+            this.txtAuthority.Location = new System.Drawing.Point(9, 114);
+            this.txtAuthority.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtAuthority.Name = "txtAuthority";
-            this.txtAuthority.Size = new System.Drawing.Size(475, 22);
+            this.txtAuthority.Size = new System.Drawing.Size(534, 26);
             this.txtAuthority.TabIndex = 2;
             // 
             // label3
             // 
             this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.label3.Location = new System.Drawing.Point(8, 20);
+            this.label3.Location = new System.Drawing.Point(9, 25);
             this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(476, 68);
+            this.label3.Size = new System.Drawing.Size(536, 85);
             this.label3.TabIndex = 107;
             this.label3.Text = resources.GetString("label3.Text");
             // 
@@ -129,11 +129,11 @@ namespace SyncKusto
             this.groupBox2.Controls.Add(this.label2);
             this.groupBox2.Controls.Add(this.txtKustoCluster);
             this.groupBox2.Controls.Add(this.label1);
-            this.groupBox2.Location = new System.Drawing.Point(16, 14);
-            this.groupBox2.Margin = new System.Windows.Forms.Padding(4);
+            this.groupBox2.Location = new System.Drawing.Point(18, 18);
+            this.groupBox2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Padding = new System.Windows.Forms.Padding(4);
-            this.groupBox2.Size = new System.Drawing.Size(492, 194);
+            this.groupBox2.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox2.Size = new System.Drawing.Size(554, 242);
             this.groupBox2.TabIndex = 6;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Temporary Databases";
@@ -143,20 +143,20 @@ namespace SyncKusto
             this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label5.ForeColor = System.Drawing.Color.Red;
-            this.label5.Location = new System.Drawing.Point(8, 98);
+            this.label5.Location = new System.Drawing.Point(9, 122);
             this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(476, 26);
+            this.label5.Size = new System.Drawing.Size(536, 32);
             this.label5.TabIndex = 101;
             this.label5.Text = "Everything in this database will be dropped before every comparison!";
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(8, 163);
+            this.label4.Location = new System.Drawing.Point(9, 204);
             this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(70, 16);
+            this.label4.Size = new System.Drawing.Size(83, 20);
             this.label4.TabIndex = 104;
             this.label4.Text = "&Database:";
             // 
@@ -164,19 +164,19 @@ namespace SyncKusto
             // 
             this.txtKustoDatabase.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtKustoDatabase.Location = new System.Drawing.Point(92, 159);
-            this.txtKustoDatabase.Margin = new System.Windows.Forms.Padding(4);
+            this.txtKustoDatabase.Location = new System.Drawing.Point(104, 199);
+            this.txtKustoDatabase.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtKustoDatabase.Name = "txtKustoDatabase";
-            this.txtKustoDatabase.Size = new System.Drawing.Size(391, 22);
+            this.txtKustoDatabase.Size = new System.Drawing.Size(439, 26);
             this.txtKustoDatabase.TabIndex = 1;
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(8, 131);
+            this.label2.Location = new System.Drawing.Point(9, 164);
             this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(51, 16);
+            this.label2.Size = new System.Drawing.Size(63, 20);
             this.label2.TabIndex = 103;
             this.label2.Text = "C&luster:";
             // 
@@ -184,20 +184,20 @@ namespace SyncKusto
             // 
             this.txtKustoCluster.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtKustoCluster.Location = new System.Drawing.Point(92, 127);
-            this.txtKustoCluster.Margin = new System.Windows.Forms.Padding(4);
+            this.txtKustoCluster.Location = new System.Drawing.Point(104, 159);
+            this.txtKustoCluster.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtKustoCluster.Name = "txtKustoCluster";
-            this.txtKustoCluster.Size = new System.Drawing.Size(391, 22);
+            this.txtKustoCluster.Size = new System.Drawing.Size(439, 26);
             this.txtKustoCluster.TabIndex = 0;
             // 
             // label1
             // 
             this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.label1.Location = new System.Drawing.Point(8, 26);
+            this.label1.Location = new System.Drawing.Point(9, 32);
             this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(476, 72);
+            this.label1.Size = new System.Drawing.Size(536, 90);
             this.label1.TabIndex = 100;
             this.label1.Text = resources.GetString("label1.Text");
             // 
@@ -206,11 +206,11 @@ namespace SyncKusto
             this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox3.Controls.Add(this.chkTableDropWarning);
-            this.groupBox3.Location = new System.Drawing.Point(16, 347);
+            this.groupBox3.Location = new System.Drawing.Point(18, 434);
             this.groupBox3.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.groupBox3.Name = "groupBox3";
             this.groupBox3.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.groupBox3.Size = new System.Drawing.Size(492, 66);
+            this.groupBox3.Size = new System.Drawing.Size(554, 82);
             this.groupBox3.TabIndex = 108;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Warnings";
@@ -218,10 +218,10 @@ namespace SyncKusto
             // chkTableDropWarning
             // 
             this.chkTableDropWarning.AutoSize = true;
-            this.chkTableDropWarning.Location = new System.Drawing.Point(12, 28);
+            this.chkTableDropWarning.Location = new System.Drawing.Point(14, 35);
             this.chkTableDropWarning.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.chkTableDropWarning.Name = "chkTableDropWarning";
-            this.chkTableDropWarning.Size = new System.Drawing.Size(366, 20);
+            this.chkTableDropWarning.Size = new System.Drawing.Size(438, 24);
             this.chkTableDropWarning.TabIndex = 3;
             this.chkTableDropWarning.Text = "&Ask before dropping objects in the target Kusto database";
             this.chkTableDropWarning.UseVisualStyleBackColor = true;
@@ -233,11 +233,11 @@ namespace SyncKusto
             this.groupBox4.Controls.Add(this.label6);
             this.groupBox4.Controls.Add(this.cbCreateMerge);
             this.groupBox4.Controls.Add(this.cbTableFieldsOnNewLine);
-            this.groupBox4.Location = new System.Drawing.Point(16, 418);
+            this.groupBox4.Location = new System.Drawing.Point(18, 522);
             this.groupBox4.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.groupBox4.Name = "groupBox4";
             this.groupBox4.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.groupBox4.Size = new System.Drawing.Size(492, 148);
+            this.groupBox4.Size = new System.Drawing.Size(554, 185);
             this.groupBox4.TabIndex = 109;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Formatting";
@@ -247,10 +247,10 @@ namespace SyncKusto
             this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.label6.Location = new System.Drawing.Point(8, 83);
+            this.label6.Location = new System.Drawing.Point(9, 104);
             this.label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(475, 54);
+            this.label6.Size = new System.Drawing.Size(534, 68);
             this.label6.TabIndex = 110;
             this.label6.Text = resources.GetString("label6.Text");
             // 
@@ -259,10 +259,10 @@ namespace SyncKusto
             this.cbCreateMerge.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.cbCreateMerge.AutoSize = true;
-            this.cbCreateMerge.Location = new System.Drawing.Point(12, 52);
+            this.cbCreateMerge.Location = new System.Drawing.Point(14, 65);
             this.cbCreateMerge.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cbCreateMerge.Name = "cbCreateMerge";
-            this.cbCreateMerge.Size = new System.Drawing.Size(433, 20);
+            this.cbCreateMerge.Size = new System.Drawing.Size(517, 24);
             this.cbCreateMerge.TabIndex = 5;
             this.cbCreateMerge.Text = "&Generate \".create-merge table\" commands instead of \".create table\"";
             this.cbCreateMerge.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -273,10 +273,10 @@ namespace SyncKusto
             this.cbTableFieldsOnNewLine.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.cbTableFieldsOnNewLine.AutoSize = true;
-            this.cbTableFieldsOnNewLine.Location = new System.Drawing.Point(12, 28);
+            this.cbTableFieldsOnNewLine.Location = new System.Drawing.Point(14, 35);
             this.cbTableFieldsOnNewLine.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cbTableFieldsOnNewLine.Name = "cbTableFieldsOnNewLine";
-            this.cbTableFieldsOnNewLine.Size = new System.Drawing.Size(208, 20);
+            this.cbTableFieldsOnNewLine.Size = new System.Drawing.Size(245, 24);
             this.cbTableFieldsOnNewLine.TabIndex = 4;
             this.cbTableFieldsOnNewLine.Text = "&Place table fields on new lines";
             this.cbTableFieldsOnNewLine.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -287,11 +287,11 @@ namespace SyncKusto
             this.groupBox5.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox5.Controls.Add(this.cbUseLegacyCslExtension);
-            this.groupBox5.Location = new System.Drawing.Point(16, 573);
+            this.groupBox5.Location = new System.Drawing.Point(18, 716);
             this.groupBox5.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.groupBox5.Name = "groupBox5";
             this.groupBox5.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.groupBox5.Size = new System.Drawing.Size(492, 59);
+            this.groupBox5.Size = new System.Drawing.Size(554, 74);
             this.groupBox5.TabIndex = 110;
             this.groupBox5.TabStop = false;
             this.groupBox5.Text = "Files";
@@ -301,10 +301,10 @@ namespace SyncKusto
             this.cbUseLegacyCslExtension.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.cbUseLegacyCslExtension.AutoSize = true;
-            this.cbUseLegacyCslExtension.Location = new System.Drawing.Point(12, 28);
+            this.cbUseLegacyCslExtension.Location = new System.Drawing.Point(14, 35);
             this.cbUseLegacyCslExtension.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cbUseLegacyCslExtension.Name = "cbUseLegacyCslExtension";
-            this.cbUseLegacyCslExtension.Size = new System.Drawing.Size(208, 20);
+            this.cbUseLegacyCslExtension.Size = new System.Drawing.Size(244, 24);
             this.cbUseLegacyCslExtension.TabIndex = 4;
             this.cbUseLegacyCslExtension.Text = "&Use legacy .csl file extensions";
             this.cbUseLegacyCslExtension.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -312,9 +312,9 @@ namespace SyncKusto
             // 
             // SettingsForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(524, 674);
+            this.ClientSize = new System.Drawing.Size(590, 842);
             this.Controls.Add(this.groupBox5);
             this.Controls.Add(this.groupBox4);
             this.Controls.Add(this.groupBox3);
@@ -323,8 +323,8 @@ namespace SyncKusto
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOk);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(4);
-            this.MinimumSize = new System.Drawing.Size(542, 721);
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.MinimumSize = new System.Drawing.Size(607, 887);
             this.Name = "SettingsForm";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.Text = "Settings";

--- a/SyncKusto/SettingsForm.cs
+++ b/SyncKusto/SettingsForm.cs
@@ -120,7 +120,7 @@ namespace SyncKusto
                     }
                     else if (ex.Message.Contains("Kusto client failed to perform authentication"))
                     {
-                        MessageBox.Show($"Could not authenticate with AAD. Please verify that the AAD Authority is specified correctly.", "Error Authenticating", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show($"Could not authenticate with Microsoft Entra ID. Please verify that the Microsoft Entra ID Authority is specified correctly.", "Error Authenticating", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                     else
                     {
@@ -150,9 +150,9 @@ namespace SyncKusto
                     if (functionCount != 0 || tableCount != 0)
                     {
                         MessageBox.Show($"Drop all functions and tables in the {txtKustoDatabase.Text} database before specifying this as the temporary database. " +
-                            $"This check is performed to reinforce the point that this databse will be wiped every time a comparison is run.", 
-                            "Error Validating Empty Database", 
-                            MessageBoxButtons.OK, 
+                            $"This check is performed to reinforce the point that this databse will be wiped every time a comparison is run.",
+                            "Error Validating Empty Database",
+                            MessageBoxButtons.OK,
                             MessageBoxIcon.Error);
                         return;
                     }

--- a/SyncKusto/SettingsForm.resx
+++ b/SyncKusto/SettingsForm.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="label3.Text" xml:space="preserve">
-    <value>Specify the AAD authority to be used for authentication (e.g. contoso.com). Depending on your tenant configuration, this may be optional, unless you're connecting with an application id in which case it is required:</value>
+    <value>Specify the Microsoft Entra ID authority to be used for authentication (e.g. contoso.com). Depending on your tenant configuration, this may be optional, unless you're connecting with an application id in which case it is required:</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>When the local file system is selected as the source or the target, SyncKusto loads all of the files into a temporary database and then asks Kusto for the database schema. Specify a Kusto cluster and database to use for the comparison. You must be a database admin.</value>

--- a/SyncKusto/SyncKusto.csproj
+++ b/SyncKusto/SyncKusto.csproj
@@ -99,6 +99,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Utilities\CertificateStore.cs" />
     <Compile Include="ChangeModel\DictionaryDifferenceMapper.cs" />
     <Compile Include="ChangeModel\Difference.cs" />
     <Compile Include="ChangeModel\Schema\FunctionSchemaDifference.cs" />

--- a/SyncKusto/Utilities/CertificateStore.cs
+++ b/SyncKusto/Utilities/CertificateStore.cs
@@ -1,0 +1,70 @@
+﻿namespace SyncKusto.Utilities
+{
+    using System;
+    using System.Security.Cryptography.X509Certificates;
+
+    internal class CertificateStore
+    {
+        /// <summary>
+        /// Find a certificate by thumbprint in the My store of either CurrentUser or LocalMachine.
+        /// </summary>
+        /// <param name="thumbprint">The thumbprint of the certificate to retrieve.</param>
+        /// <returns>The requested certificate</returns>
+        public static X509Certificate2 GetCertificate(string thumbprint)
+        {
+            var certificate = GetCertificate(StoreLocation.CurrentUser, StoreName.My, thumbprint);
+            if (certificate == null)
+            {
+                certificate = GetCertificate(StoreLocation.LocalMachine, StoreName.My, thumbprint);
+            }
+
+            if (certificate == null)
+            {
+                throw new Exception($"Cannot find certificate with thumbprint: {thumbprint}");
+            }
+
+            return certificate;
+        }
+
+        /// <summary>
+        /// Get all the certificates in both the Current User and Local Machine locations.
+        /// </summary>
+        /// <returns>A collection of certificates</returns>
+        public static X509Certificate2Collection GetAllCertificates()
+        {
+            X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+            store.Open(OpenFlags.ReadOnly);
+            X509Certificate2Collection certificates = store.Certificates;
+            store.Close();
+
+            store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
+            store.Open(OpenFlags.ReadOnly);
+            certificates.AddRange(store.Certificates);
+            store.Close();
+
+            return certificates;
+        }
+
+        /// <summary>
+        /// Find a certificate by thumbprint in the specified store and location.
+        /// </summary>
+        /// <param name="storeLocation">The location of the store to search for the certificate.</param>
+        /// <param name="storeName">The name of the store to search for the certificate.</param>
+        /// <param name="thumbprint">The thumbprint of the certificate to retrieve.</param>
+        /// <returns>The requested certificate or null if it is not found.</returns>
+        private static X509Certificate2 GetCertificate(StoreLocation storeLocation, StoreName storeName, string thumbprint)
+        {
+            var certStore = new X509Store(storeName, storeLocation);
+            certStore.Open(OpenFlags.ReadOnly);
+            var certCollection = certStore.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, false);
+            certStore.Close();
+
+            if (certCollection.Count == 0)
+            {
+                return null;
+            }
+
+            return certCollection[0];
+        }
+    }
+}


### PR DESCRIPTION
This change adds a third option to the ways to connect. User auth and App key auth are still supported but there's a new option for using an App with SubjectName/Issuer auth. For this flow, the certificate must be installed on the user's machine in the My store of either the Local Machine or CurrentUser location. The certificate can be selected either with the button to the right of the text box or by entering in the thumbprint directly.