### PR TITLE
Update Kusto NuGet packages

### DIFF
--- a/SyncKusto/SyncKusto.csproj
+++ b/SyncKusto/SyncKusto.csproj
@@ -231,7 +231,7 @@
       <Version>1.4.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.Kusto.Data">
-      <Version>12.0.1</Version>
+      <Version>12.2.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>


### PR DESCRIPTION
Update Kusto NuGet package from 12.0.1 for 12.2.0. This is being done proactively. There are no known issues.