### PR TITLE
Cert Location Setting and Recently Used Strings

### DIFF
--- a/SyncKusto/App.config
+++ b/SyncKusto/App.config
@@ -34,6 +34,9 @@
       <setting name="UseLegacyCslExtension" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="CertificateLocation" serializeAs="String">
+        <value />
+      </setting>
     </SyncKusto.Properties.Settings>
   </userSettings>
 </configuration>

--- a/SyncKusto/App.config
+++ b/SyncKusto/App.config
@@ -35,7 +35,7 @@
         <value>True</value>
       </setting>
       <setting name="CertificateLocation" serializeAs="String">
-        <value />
+        <value>CurrentUser</value>
       </setting>
     </SyncKusto.Properties.Settings>
   </userSettings>

--- a/SyncKusto/MainForm.Designer.cs
+++ b/SyncKusto/MainForm.Designer.cs
@@ -150,7 +150,7 @@ namespace SyncKusto
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(81, 13);
             this.label2.TabIndex = 6;
-            this.label2.Text = "Build 20240419";
+            this.label2.Text = "Build 20240422";
             // 
             // spcTargetHolder
             // 

--- a/SyncKusto/MainForm.cs
+++ b/SyncKusto/MainForm.cs
@@ -147,6 +147,16 @@ namespace SyncKusto
 
             spcSource.ReportProgress(string.Empty);
             spcTarget.ReportProgress(string.Empty);
+
+            // Save the cluster and databases used in recent history to populate the combo boxes for
+            // next time and then reload them both. (Note that combining save an reload into a
+            // single operation would mean that the source recent history list wouldn't contain
+            // whatever was just used in the target schema so we keep them as separate steps.)
+            spcSource.SaveRecentValues();
+            spcTarget.SaveRecentValues();
+            spcSource.ReloadRecentValues();
+            spcTarget.ReloadRecentValues();
+
             // Enable the update button now that a comparison has been generated.
             btnUpdate.Enabled = true;
         }

--- a/SyncKusto/Properties/Settings.Designer.cs
+++ b/SyncKusto/Properties/Settings.Designer.cs
@@ -118,5 +118,17 @@ namespace SyncKusto.Properties {
                 this["UseLegacyCslExtension"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string CertificateLocation {
+            get {
+                return ((string)(this["CertificateLocation"]));
+            }
+            set {
+                this["CertificateLocation"] = value;
+            }
+        }
     }
 }

--- a/SyncKusto/Properties/Settings.Designer.cs
+++ b/SyncKusto/Properties/Settings.Designer.cs
@@ -130,5 +130,27 @@ namespace SyncKusto.Properties {
                 this["CertificateLocation"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        public global::System.Collections.Specialized.StringCollection RecentClusters {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["RecentClusters"]));
+            }
+            set {
+                this["RecentClusters"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        public global::System.Collections.Specialized.StringCollection RecentDatabases {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["RecentDatabases"]));
+            }
+            set {
+                this["RecentDatabases"] = value;
+            }
+        }
     }
 }

--- a/SyncKusto/Properties/Settings.Designer.cs
+++ b/SyncKusto/Properties/Settings.Designer.cs
@@ -152,5 +152,16 @@ namespace SyncKusto.Properties {
                 this["RecentDatabases"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        public global::System.Collections.Specialized.StringCollection RecentAppIds {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["RecentAppIds"]));
+            }
+            set {
+                this["RecentAppIds"] = value;
+            }
+        }
     }
 }

--- a/SyncKusto/Properties/Settings.Designer.cs
+++ b/SyncKusto/Properties/Settings.Designer.cs
@@ -121,7 +121,7 @@ namespace SyncKusto.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        [global::System.Configuration.DefaultSettingValueAttribute("CurrentUser")]
         public string CertificateLocation {
             get {
                 return ((string)(this["CertificateLocation"]));

--- a/SyncKusto/Properties/Settings.settings
+++ b/SyncKusto/Properties/Settings.settings
@@ -29,5 +29,11 @@
     <Setting Name="CertificateLocation" Type="System.String" Scope="User">
       <Value Profile="(Default)">CurrentUser</Value>
     </Setting>
+    <Setting Name="RecentClusters" Type="System.Collections.Specialized.StringCollection" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="RecentDatabases" Type="System.Collections.Specialized.StringCollection" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/SyncKusto/Properties/Settings.settings
+++ b/SyncKusto/Properties/Settings.settings
@@ -35,5 +35,8 @@
     <Setting Name="RecentDatabases" Type="System.Collections.Specialized.StringCollection" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="RecentAppIds" Type="System.Collections.Specialized.StringCollection" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/SyncKusto/Properties/Settings.settings
+++ b/SyncKusto/Properties/Settings.settings
@@ -26,5 +26,8 @@
     <Setting Name="UseLegacyCslExtension" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="CertificateLocation" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/SyncKusto/Properties/Settings.settings
+++ b/SyncKusto/Properties/Settings.settings
@@ -27,7 +27,7 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="CertificateLocation" Type="System.String" Scope="User">
-      <Value Profile="(Default)" />
+      <Value Profile="(Default)">CurrentUser</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/SyncKusto/SchemaPickerControl.Designer.cs
+++ b/SyncKusto/SchemaPickerControl.Designer.cs
@@ -41,13 +41,11 @@ namespace SyncKusto
             this.btnCertificate = new System.Windows.Forms.Button();
             this.txtCertificate = new System.Windows.Forms.TextBox();
             this.lblCertificate = new System.Windows.Forms.Label();
-            this.txtAppIdSni = new System.Windows.Forms.TextBox();
             this.lblAppIdSni = new System.Windows.Forms.Label();
             this.cmbAuthentication = new System.Windows.Forms.ComboBox();
             this.pnlApplicationAuthentication = new System.Windows.Forms.Panel();
             this.txtAppKey = new System.Windows.Forms.TextBox();
             this.lblAppKey = new System.Windows.Forms.Label();
-            this.txtAppId = new System.Windows.Forms.TextBox();
             this.lblAppId = new System.Windows.Forms.Label();
             this.lblDatabase = new System.Windows.Forms.Label();
             this.lblCluster = new System.Windows.Forms.Label();
@@ -59,6 +57,8 @@ namespace SyncKusto
             this.rbFilePath = new System.Windows.Forms.RadioButton();
             this.cbCluster = new System.Windows.Forms.ComboBox();
             this.cbDatabase = new System.Windows.Forms.ComboBox();
+            this.cbAppIdSni = new System.Windows.Forms.ComboBox();
+            this.cbAppId = new System.Windows.Forms.ComboBox();
             this.grpSourceSchema.SuspendLayout();
             this.pnlKusto.SuspendLayout();
             this.grpAuthentication.SuspendLayout();
@@ -106,8 +106,8 @@ namespace SyncKusto
             // 
             // grpAuthentication
             // 
-            this.grpAuthentication.Controls.Add(this.pnlApplicationSniAuthentication);
             this.grpAuthentication.Controls.Add(this.cmbAuthentication);
+            this.grpAuthentication.Controls.Add(this.pnlApplicationSniAuthentication);
             this.grpAuthentication.Controls.Add(this.pnlApplicationAuthentication);
             this.grpAuthentication.Location = new System.Drawing.Point(10, 86);
             this.grpAuthentication.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
@@ -121,10 +121,10 @@ namespace SyncKusto
             // 
             // pnlApplicationSniAuthentication
             // 
+            this.pnlApplicationSniAuthentication.Controls.Add(this.cbAppIdSni);
             this.pnlApplicationSniAuthentication.Controls.Add(this.btnCertificate);
             this.pnlApplicationSniAuthentication.Controls.Add(this.txtCertificate);
             this.pnlApplicationSniAuthentication.Controls.Add(this.lblCertificate);
-            this.pnlApplicationSniAuthentication.Controls.Add(this.txtAppIdSni);
             this.pnlApplicationSniAuthentication.Controls.Add(this.lblAppIdSni);
             this.pnlApplicationSniAuthentication.Location = new System.Drawing.Point(9, 71);
             this.pnlApplicationSniAuthentication.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
@@ -161,14 +161,6 @@ namespace SyncKusto
             this.lblCertificate.TabIndex = 6;
             this.lblCertificate.Text = "Certificate Thumbprint:";
             // 
-            // txtAppIdSni
-            // 
-            this.txtAppIdSni.Location = new System.Drawing.Point(180, 8);
-            this.txtAppIdSni.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.txtAppIdSni.Name = "txtAppIdSni";
-            this.txtAppIdSni.Size = new System.Drawing.Size(204, 26);
-            this.txtAppIdSni.TabIndex = 5;
-            // 
             // lblAppIdSni
             // 
             this.lblAppIdSni.AutoSize = true;
@@ -190,9 +182,9 @@ namespace SyncKusto
             // 
             // pnlApplicationAuthentication
             // 
+            this.pnlApplicationAuthentication.Controls.Add(this.cbAppId);
             this.pnlApplicationAuthentication.Controls.Add(this.txtAppKey);
             this.pnlApplicationAuthentication.Controls.Add(this.lblAppKey);
-            this.pnlApplicationAuthentication.Controls.Add(this.txtAppId);
             this.pnlApplicationAuthentication.Controls.Add(this.lblAppId);
             this.pnlApplicationAuthentication.Location = new System.Drawing.Point(9, 71);
             this.pnlApplicationAuthentication.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
@@ -219,14 +211,6 @@ namespace SyncKusto
             this.lblAppKey.Size = new System.Drawing.Size(72, 20);
             this.lblAppKey.TabIndex = 6;
             this.lblAppKey.Text = "App Key:";
-            // 
-            // txtAppId
-            // 
-            this.txtAppId.Location = new System.Drawing.Point(96, 8);
-            this.txtAppId.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.txtAppId.Name = "txtAppId";
-            this.txtAppId.Size = new System.Drawing.Size(288, 26);
-            this.txtAppId.TabIndex = 5;
             // 
             // lblAppId
             // 
@@ -342,6 +326,22 @@ namespace SyncKusto
             this.cbDatabase.Size = new System.Drawing.Size(314, 28);
             this.cbDatabase.TabIndex = 6;
             // 
+            // cbAppIdSni
+            // 
+            this.cbAppIdSni.FormattingEnabled = true;
+            this.cbAppIdSni.Location = new System.Drawing.Point(70, 8);
+            this.cbAppIdSni.Name = "cbAppIdSni";
+            this.cbAppIdSni.Size = new System.Drawing.Size(314, 28);
+            this.cbAppIdSni.TabIndex = 9;
+            // 
+            // cbAppId
+            // 
+            this.cbAppId.FormattingEnabled = true;
+            this.cbAppId.Location = new System.Drawing.Point(70, 8);
+            this.cbAppId.Name = "cbAppId";
+            this.cbAppId.Size = new System.Drawing.Size(314, 28);
+            this.cbAppId.TabIndex = 10;
+            // 
             // SchemaPickerControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
@@ -380,7 +380,6 @@ namespace SyncKusto
         private System.Windows.Forms.Panel pnlApplicationAuthentication;
         private System.Windows.Forms.TextBox txtAppKey;
         private System.Windows.Forms.Label lblAppKey;
-        private System.Windows.Forms.TextBox txtAppId;
         private System.Windows.Forms.Label lblAppId;
         private System.Windows.Forms.Label lblExample;
         private System.Windows.Forms.Label txtOperationProgress;
@@ -389,9 +388,10 @@ namespace SyncKusto
         private System.Windows.Forms.Button btnCertificate;
         private System.Windows.Forms.TextBox txtCertificate;
         private System.Windows.Forms.Label lblCertificate;
-        private System.Windows.Forms.TextBox txtAppIdSni;
         private System.Windows.Forms.Label lblAppIdSni;
         private System.Windows.Forms.ComboBox cbCluster;
         private System.Windows.Forms.ComboBox cbDatabase;
+        private System.Windows.Forms.ComboBox cbAppIdSni;
+        private System.Windows.Forms.ComboBox cbAppId;
     }
 }

--- a/SyncKusto/SchemaPickerControl.Designer.cs
+++ b/SyncKusto/SchemaPickerControl.Designer.cs
@@ -49,9 +49,7 @@ namespace SyncKusto
             this.lblAppKey = new System.Windows.Forms.Label();
             this.txtAppId = new System.Windows.Forms.TextBox();
             this.lblAppId = new System.Windows.Forms.Label();
-            this.txtDatabase = new System.Windows.Forms.TextBox();
             this.lblDatabase = new System.Windows.Forms.Label();
-            this.txtCluster = new System.Windows.Forms.TextBox();
             this.lblCluster = new System.Windows.Forms.Label();
             this.pnlFilePath = new System.Windows.Forms.Panel();
             this.lblExample = new System.Windows.Forms.Label();
@@ -59,6 +57,8 @@ namespace SyncKusto
             this.btnChooseDirectory = new System.Windows.Forms.Button();
             this.rbKusto = new System.Windows.Forms.RadioButton();
             this.rbFilePath = new System.Windows.Forms.RadioButton();
+            this.cbCluster = new System.Windows.Forms.ComboBox();
+            this.cbDatabase = new System.Windows.Forms.ComboBox();
             this.grpSourceSchema.SuspendLayout();
             this.pnlKusto.SuspendLayout();
             this.grpAuthentication.SuspendLayout();
@@ -93,10 +93,10 @@ namespace SyncKusto
             // 
             // pnlKusto
             // 
+            this.pnlKusto.Controls.Add(this.cbDatabase);
+            this.pnlKusto.Controls.Add(this.cbCluster);
             this.pnlKusto.Controls.Add(this.grpAuthentication);
-            this.pnlKusto.Controls.Add(this.txtDatabase);
             this.pnlKusto.Controls.Add(this.lblDatabase);
-            this.pnlKusto.Controls.Add(this.txtCluster);
             this.pnlKusto.Controls.Add(this.lblCluster);
             this.pnlKusto.Location = new System.Drawing.Point(9, 66);
             this.pnlKusto.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
@@ -238,14 +238,6 @@ namespace SyncKusto
             this.lblAppId.TabIndex = 4;
             this.lblAppId.Text = "App Id:";
             // 
-            // txtDatabase
-            // 
-            this.txtDatabase.Location = new System.Drawing.Point(99, 44);
-            this.txtDatabase.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.txtDatabase.Name = "txtDatabase";
-            this.txtDatabase.Size = new System.Drawing.Size(314, 26);
-            this.txtDatabase.TabIndex = 3;
-            // 
             // lblDatabase
             // 
             this.lblDatabase.AutoSize = true;
@@ -255,14 +247,6 @@ namespace SyncKusto
             this.lblDatabase.Size = new System.Drawing.Size(83, 20);
             this.lblDatabase.TabIndex = 2;
             this.lblDatabase.Text = "Database:";
-            // 
-            // txtCluster
-            // 
-            this.txtCluster.Location = new System.Drawing.Point(99, 4);
-            this.txtCluster.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.txtCluster.Name = "txtCluster";
-            this.txtCluster.Size = new System.Drawing.Size(314, 26);
-            this.txtCluster.TabIndex = 1;
             // 
             // lblCluster
             // 
@@ -342,6 +326,22 @@ namespace SyncKusto
             this.rbFilePath.UseVisualStyleBackColor = true;
             this.rbFilePath.CheckedChanged += new System.EventHandler(this.rbFilePath_CheckedChanged);
             // 
+            // cbCluster
+            // 
+            this.cbCluster.FormattingEnabled = true;
+            this.cbCluster.Location = new System.Drawing.Point(99, 6);
+            this.cbCluster.Name = "cbCluster";
+            this.cbCluster.Size = new System.Drawing.Size(314, 28);
+            this.cbCluster.TabIndex = 5;
+            // 
+            // cbDatabase
+            // 
+            this.cbDatabase.FormattingEnabled = true;
+            this.cbDatabase.Location = new System.Drawing.Point(99, 43);
+            this.cbDatabase.Name = "cbDatabase";
+            this.cbDatabase.Size = new System.Drawing.Size(314, 28);
+            this.cbDatabase.TabIndex = 6;
+            // 
             // SchemaPickerControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
@@ -374,9 +374,7 @@ namespace SyncKusto
         private System.Windows.Forms.RadioButton rbKusto;
         private System.Windows.Forms.RadioButton rbFilePath;
         private System.Windows.Forms.Panel pnlKusto;
-        private System.Windows.Forms.TextBox txtDatabase;
         private System.Windows.Forms.Label lblDatabase;
-        private System.Windows.Forms.TextBox txtCluster;
         private System.Windows.Forms.Label lblCluster;
         private System.Windows.Forms.GroupBox grpAuthentication;
         private System.Windows.Forms.Panel pnlApplicationAuthentication;
@@ -393,5 +391,7 @@ namespace SyncKusto
         private System.Windows.Forms.Label lblCertificate;
         private System.Windows.Forms.TextBox txtAppIdSni;
         private System.Windows.Forms.Label lblAppIdSni;
+        private System.Windows.Forms.ComboBox cbCluster;
+        private System.Windows.Forms.ComboBox cbDatabase;
     }
 }

--- a/SyncKusto/SchemaPickerControl.cs
+++ b/SyncKusto/SchemaPickerControl.cs
@@ -41,6 +41,7 @@ namespace SyncKusto
             this.cmbAuthentication.SelectedIndex = 0;
 
             this.cbCluster.Items.AddRange(SettingsWrapper.RecentClusters.ToArray());
+            this.cbDatabase.Items.AddRange(SettingsWrapper.RecentDatabases.ToArray());
         }
 
         /// <summary>
@@ -317,8 +318,19 @@ namespace SyncKusto
         /// </summary>
         public void SaveRecentValues()
         {
-            SettingsWrapper.AddRecentCluster(cbCluster.Text);
-            SettingsWrapper.AddRecentDatabase(cbDatabase.Text);
+            SettingsWrapper.AddRecentCluster(this.cbCluster.Text);
+            SettingsWrapper.AddRecentDatabase(this.cbDatabase.Text);
+        }
+
+        /// <summary>
+        /// For the inputs where we store recents, reload them all with the latest values.
+        /// </summary>
+        public void ReloadRecentValues()
+        {
+            this.cbCluster.Items.Clear();
+            this.cbCluster.Items.AddRange(SettingsWrapper.RecentClusters.ToArray());
+            this.cbDatabase.Items.Clear();
+            this.cbDatabase.Items.AddRange(SettingsWrapper.RecentDatabases.ToArray());
         }
     }
 }

--- a/SyncKusto/SchemaPickerControl.cs
+++ b/SyncKusto/SchemaPickerControl.cs
@@ -318,6 +318,7 @@ namespace SyncKusto
         public void SaveRecentValues()
         {
             SettingsWrapper.AddRecentCluster(cbCluster.Text);
+            SettingsWrapper.AddRecentDatabase(cbDatabase.Text);
         }
     }
 }

--- a/SyncKusto/SchemaPickerControl.cs
+++ b/SyncKusto/SchemaPickerControl.cs
@@ -39,6 +39,8 @@ namespace SyncKusto
                     ENTRA_ID_APP_SNI });
 
             this.cmbAuthentication.SelectedIndex = 0;
+
+            this.cbCluster.Items.AddRange(SettingsWrapper.RecentClusters.ToArray());
         }
 
         /// <summary>
@@ -307,6 +309,15 @@ namespace SyncKusto
             {
                 txtCertificate.Text = selectedCertificateCollection[0].Thumbprint;
             }
+        }
+
+        /// <summary>
+        /// For some of the inputs, we save the most recent values that were used. This method
+        /// updates the storage behind all those settings to include the most recently used values.
+        /// </summary>
+        public void SaveRecentValues()
+        {
+            SettingsWrapper.AddRecentCluster(cbCluster.Text);
         }
     }
 }

--- a/SyncKusto/SchemaPickerControl.cs
+++ b/SyncKusto/SchemaPickerControl.cs
@@ -106,19 +106,19 @@ namespace SyncKusto
                 switch (Authentication)
                 {
                     case AuthenticationMode.AadFederated:
-                        return QueryEngine.GetKustoConnectionStringBuilder(txtCluster.Text, txtDatabase.Text);
+                        return QueryEngine.GetKustoConnectionStringBuilder(cbCluster.Text, cbDatabase.Text);
 
                     case AuthenticationMode.AadApplication:
                         return QueryEngine.GetKustoConnectionStringBuilder(
-                            txtCluster.Text,
-                            txtDatabase.Text,
+                            cbCluster.Text,
+                            cbDatabase.Text,
                             aadClientId: txtAppId.Text,
                             aadClientKey: txtAppKey.Text);
 
                     case AuthenticationMode.AadApplicationSni:
                         return QueryEngine.GetKustoConnectionStringBuilder(
-                            txtCluster.Text,
-                            txtDatabase.Text,
+                            cbCluster.Text,
+                            cbDatabase.Text,
                             aadClientId: txtAppIdSni.Text,
                             certificateThumbprint: txtCertificate.Text);
 
@@ -160,8 +160,8 @@ namespace SyncKusto
         private bool KustoSourceSpecification() =>
             Spec<SchemaPickerControl>
                 .IsTrue(s => s.SourceSelection == SourceSelection.Kusto())
-                .And(Spec<SchemaPickerControl>.NonEmptyString(s => s.txtCluster.Text))
-                .And(Spec<SchemaPickerControl>.NonEmptyString(s => s.txtDatabase.Text))
+                .And(Spec<SchemaPickerControl>.NonEmptyString(s => s.cbCluster.Text))
+                .And(Spec<SchemaPickerControl>.NonEmptyString(s => s.cbDatabase.Text))
                 .And(
                     Spec<SchemaPickerControl>.IsTrue(s => s.Authentication == AuthenticationMode.AadFederated)
                         .Or(Spec<SchemaPickerControl>

--- a/SyncKusto/SchemaPickerControl.cs
+++ b/SyncKusto/SchemaPickerControl.cs
@@ -115,14 +115,14 @@ namespace SyncKusto
                         return QueryEngine.GetKustoConnectionStringBuilder(
                             cbCluster.Text,
                             cbDatabase.Text,
-                            aadClientId: txtAppId.Text,
+                            aadClientId: cbAppId.Text,
                             aadClientKey: txtAppKey.Text);
 
                     case AuthenticationMode.AadApplicationSni:
                         return QueryEngine.GetKustoConnectionStringBuilder(
                             cbCluster.Text,
                             cbDatabase.Text,
-                            aadClientId: txtAppIdSni.Text,
+                            aadClientId: cbAppIdSni.Text,
                             certificateThumbprint: txtCertificate.Text);
 
                     default:
@@ -169,11 +169,11 @@ namespace SyncKusto
                     Spec<SchemaPickerControl>.IsTrue(s => s.Authentication == AuthenticationMode.AadFederated)
                         .Or(Spec<SchemaPickerControl>
                             .IsTrue(s => s.Authentication == AuthenticationMode.AadApplication)
-                            .And(Spec<SchemaPickerControl>.NonEmptyString(s => s.txtAppId.Text)
+                            .And(Spec<SchemaPickerControl>.NonEmptyString(s => s.cbAppId.Text)
                                 .And(Spec<SchemaPickerControl>.NonEmptyString(s => s.txtAppKey.Text))))
                         .Or(Spec<SchemaPickerControl>
                             .IsTrue(s => s.Authentication == AuthenticationMode.AadApplicationSni)
-                            .And(Spec<SchemaPickerControl>.NonEmptyString(s => s.txtAppIdSni.Text)
+                            .And(Spec<SchemaPickerControl>.NonEmptyString(s => s.cbAppIdSni.Text)
                                 .And(Spec<SchemaPickerControl>.NonEmptyString(s => s.txtCertificate.Text)))))
                 .IsSatisfiedBy(this);
 
@@ -320,6 +320,8 @@ namespace SyncKusto
         {
             SettingsWrapper.AddRecentCluster(this.cbCluster.Text);
             SettingsWrapper.AddRecentDatabase(this.cbDatabase.Text);
+            SettingsWrapper.AddRecentAppId(this.cbAppId.Text);
+            SettingsWrapper.AddRecentAppId(this.cbAppIdSni.Text);
         }
 
         /// <summary>
@@ -331,6 +333,10 @@ namespace SyncKusto
             this.cbCluster.Items.AddRange(SettingsWrapper.RecentClusters.ToArray());
             this.cbDatabase.Items.Clear();
             this.cbDatabase.Items.AddRange(SettingsWrapper.RecentDatabases.ToArray());
+            this.cbAppId.Items.Clear();
+            this.cbAppId.Items.AddRange(SettingsWrapper.RecentAppIds.ToArray());
+            this.cbAppIdSni.Items.Clear();
+            this.cbAppIdSni.Items.AddRange(SettingsWrapper.RecentAppIds.ToArray());
         }
     }
 }

--- a/SyncKusto/SchemaPickerControl.cs
+++ b/SyncKusto/SchemaPickerControl.cs
@@ -297,7 +297,7 @@ namespace SyncKusto
         {
             // Show the certificate selection dialog
             var selectedCertificateCollection = X509Certificate2UI.SelectFromCollection(
-                CertificateStore.GetAllCertificates(),
+                CertificateStore.GetAllCertificates(SettingsWrapper.CertificateLocation),
                 "Select a certificate",
                 "Choose a certificate for authentication",
                 X509SelectionFlag.SingleSelection);

--- a/SyncKusto/SettingsForm.Designer.cs
+++ b/SyncKusto/SettingsForm.Designer.cs
@@ -41,6 +41,8 @@ namespace SyncKusto
             this.txtKustoCluster = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
             this.tcEntraId = new System.Windows.Forms.TabPage();
+            this.cbCertLocation = new System.Windows.Forms.ComboBox();
+            this.label6 = new System.Windows.Forms.Label();
             this.txtAuthority = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
             this.tcWarnings = new System.Windows.Forms.TabPage();
@@ -52,8 +54,6 @@ namespace SyncKusto
             this.cbTableFieldsOnNewLine = new System.Windows.Forms.CheckBox();
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnOk = new System.Windows.Forms.Button();
-            this.label6 = new System.Windows.Forms.Label();
-            this.cbCertLocation = new System.Windows.Forms.ComboBox();
             this.tabControl.SuspendLayout();
             this.tpTempDatabase.SuspendLayout();
             this.tcEntraId.SuspendLayout();
@@ -168,6 +168,26 @@ namespace SyncKusto
             this.tcEntraId.TabIndex = 1;
             this.tcEntraId.Text = "Authentication";
             this.tcEntraId.UseVisualStyleBackColor = true;
+            // 
+            // cbCertLocation
+            // 
+            this.cbCertLocation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbCertLocation.FormattingEnabled = true;
+            this.cbCertLocation.Location = new System.Drawing.Point(8, 191);
+            this.cbCertLocation.Name = "cbCertLocation";
+            this.cbCertLocation.Size = new System.Drawing.Size(501, 28);
+            this.cbCertLocation.TabIndex = 111;
+            // 
+            // label6
+            // 
+            this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.label6.Location = new System.Drawing.Point(4, 163);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(498, 25);
+            this.label6.TabIndex = 110;
+            this.label6.Text = "Certificate Location for Subject Name Issuer Auth:";
             // 
             // txtAuthority
             // 
@@ -302,26 +322,6 @@ namespace SyncKusto
             this.btnOk.Text = "O&K";
             this.btnOk.UseVisualStyleBackColor = true;
             this.btnOk.Click += new System.EventHandler(this.btnOk_Click);
-            // 
-            // label6
-            // 
-            this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.label6.Location = new System.Drawing.Point(4, 143);
-            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(498, 25);
-            this.label6.TabIndex = 110;
-            this.label6.Text = "Certificate Location for Subject Name Issuer Auth:";
-            // 
-            // cbCertLocation
-            // 
-            this.cbCertLocation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cbCertLocation.FormattingEnabled = true;
-            this.cbCertLocation.Location = new System.Drawing.Point(8, 171);
-            this.cbCertLocation.Name = "cbCertLocation";
-            this.cbCertLocation.Size = new System.Drawing.Size(501, 28);
-            this.cbCertLocation.TabIndex = 111;
             // 
             // SettingsForm
             // 

--- a/SyncKusto/SettingsForm.Designer.cs
+++ b/SyncKusto/SettingsForm.Designer.cs
@@ -52,6 +52,8 @@ namespace SyncKusto
             this.cbTableFieldsOnNewLine = new System.Windows.Forms.CheckBox();
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnOk = new System.Windows.Forms.Button();
+            this.label6 = new System.Windows.Forms.Label();
+            this.cbCertLocation = new System.Windows.Forms.ComboBox();
             this.tabControl.SuspendLayout();
             this.tpTempDatabase.SuspendLayout();
             this.tcEntraId.SuspendLayout();
@@ -155,6 +157,8 @@ namespace SyncKusto
             // 
             // tcEntraId
             // 
+            this.tcEntraId.Controls.Add(this.cbCertLocation);
+            this.tcEntraId.Controls.Add(this.label6);
             this.tcEntraId.Controls.Add(this.txtAuthority);
             this.tcEntraId.Controls.Add(this.label3);
             this.tcEntraId.Location = new System.Drawing.Point(4, 29);
@@ -162,7 +166,7 @@ namespace SyncKusto
             this.tcEntraId.Padding = new System.Windows.Forms.Padding(3, 10, 3, 10);
             this.tcEntraId.Size = new System.Drawing.Size(526, 248);
             this.tcEntraId.TabIndex = 1;
-            this.tcEntraId.Text = "Entra Id";
+            this.tcEntraId.Text = "Authentication";
             this.tcEntraId.UseVisualStyleBackColor = true;
             // 
             // txtAuthority
@@ -299,6 +303,26 @@ namespace SyncKusto
             this.btnOk.UseVisualStyleBackColor = true;
             this.btnOk.Click += new System.EventHandler(this.btnOk_Click);
             // 
+            // label6
+            // 
+            this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.label6.Location = new System.Drawing.Point(4, 143);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(498, 25);
+            this.label6.TabIndex = 110;
+            this.label6.Text = "Certificate Location for Subject Name Issuer Auth:";
+            // 
+            // cbCertLocation
+            // 
+            this.cbCertLocation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbCertLocation.FormattingEnabled = true;
+            this.cbCertLocation.Location = new System.Drawing.Point(8, 171);
+            this.cbCertLocation.Name = "cbCertLocation";
+            this.cbCertLocation.Size = new System.Drawing.Size(501, 28);
+            this.cbCertLocation.TabIndex = 111;
+            // 
             // SettingsForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
@@ -347,5 +371,7 @@ namespace SyncKusto
         private System.Windows.Forms.CheckBox cbUseLegacyCslExtension;
         private System.Windows.Forms.Button btnCancel;
         private System.Windows.Forms.Button btnOk;
+        private System.Windows.Forms.ComboBox cbCertLocation;
+        private System.Windows.Forms.Label label6;
     }
 }

--- a/SyncKusto/SettingsForm.cs
+++ b/SyncKusto/SettingsForm.cs
@@ -8,6 +8,7 @@ using SyncKusto.Kusto;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Security.Cryptography.X509Certificates;
 using System.Windows.Forms;
 
 namespace SyncKusto
@@ -23,6 +24,8 @@ namespace SyncKusto
         public SettingsForm()
         {
             InitializeComponent();
+
+            cbCertLocation.Items.AddRange(Enum.GetNames(typeof(StoreLocation)));
         }
 
         /// <summary>
@@ -39,6 +42,7 @@ namespace SyncKusto
             cbTableFieldsOnNewLine.Checked = SettingsWrapper.TableFieldsOnNewLine ?? false;
             cbCreateMerge.Checked = SettingsWrapper.CreateMergeEnabled ?? false;
             cbUseLegacyCslExtension.Checked = SettingsWrapper.UseLegacyCslExtension ?? false;
+            cbCertLocation.SelectedItem = SettingsWrapper.CertificateLocation;
         }
 
         /// <summary>
@@ -56,6 +60,7 @@ namespace SyncKusto
             SettingsWrapper.KustoObjectDropWarning = chkTableDropWarning.Checked;
             SettingsWrapper.AADAuthority = txtAuthority.Text;
             SettingsWrapper.UseLegacyCslExtension = cbUseLegacyCslExtension.Checked;
+            SettingsWrapper.CertificateLocation = cbCertLocation.SelectedItem.ToString();
 
             // Only check the Kusto settings if they changed
             if (SettingsWrapper.KustoClusterForTempDatabases != txtKustoCluster.Text ||

--- a/SyncKusto/SettingsForm.cs
+++ b/SyncKusto/SettingsForm.cs
@@ -25,7 +25,7 @@ namespace SyncKusto
         {
             InitializeComponent();
 
-            cbCertLocation.Items.AddRange(Enum.GetNames(typeof(StoreLocation)));
+            cbCertLocation.DataSource = Enum.GetValues(typeof(StoreLocation));
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace SyncKusto
             SettingsWrapper.KustoObjectDropWarning = chkTableDropWarning.Checked;
             SettingsWrapper.AADAuthority = txtAuthority.Text;
             SettingsWrapper.UseLegacyCslExtension = cbUseLegacyCslExtension.Checked;
-            SettingsWrapper.CertificateLocation = cbCertLocation.SelectedItem.ToString();
+            SettingsWrapper.CertificateLocation = (StoreLocation)cbCertLocation.SelectedItem;
 
             // Only check the Kusto settings if they changed
             if (SettingsWrapper.KustoClusterForTempDatabases != txtKustoCluster.Text ||

--- a/SyncKusto/SettingsForm.resx
+++ b/SyncKusto/SettingsForm.resx
@@ -117,11 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label3.Text" xml:space="preserve">
-    <value>Specify the Entra ID authority to be used for authentication (e.g. contoso.com). Depending on your tenant configuration, this may be optional, unless you're connecting with an application id in which case it is required:</value>
-  </data>
   <data name="label1.Text" xml:space="preserve">
     <value>When the local file system is selected as the source or the target, SyncKusto loads all of the files into a temporary database and then asks Kusto for the database schema. Specify a Kusto cluster and database to use for the comparison. You must be a database admin.</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>Specify the Entra ID authority to be used for authentication (e.g. contoso.com). Depending on your tenant configuration, this may be optional, unless you're connecting with an application id in which case it is required:</value>
   </data>
   <data name="label7.Text" xml:space="preserve">
     <value>These settings are only applied when a file is written. They do not affect the comparison operation. To apply this to all existing files, delete all the files locally, execute the comparison again and then update the local files.</value>

--- a/SyncKusto/SettingsForm.resx
+++ b/SyncKusto/SettingsForm.resx
@@ -117,11 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve">
-    <value>When the local file system is selected as the source or the target, SyncKusto loads all of the files into a temporary database and then asks Kusto for the database schema. Specify a Kusto cluster and database to use for the comparison. You must be a database admin.</value>
-  </data>
   <data name="label3.Text" xml:space="preserve">
     <value>Specify the Entra ID authority to be used for authentication (e.g. contoso.com). Depending on your tenant configuration, this may be optional, unless you're connecting with an application id in which case it is required:</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>When the local file system is selected as the source or the target, SyncKusto loads all of the files into a temporary database and then asks Kusto for the database schema. Specify a Kusto cluster and database to use for the comparison. You must be a database admin.</value>
   </data>
   <data name="label7.Text" xml:space="preserve">
     <value>These settings are only applied when a file is written. They do not affect the comparison operation. To apply this to all existing files, delete all the files locally, execute the comparison again and then update the local files.</value>

--- a/SyncKusto/SettingsWrapper.cs
+++ b/SyncKusto/SettingsWrapper.cs
@@ -191,7 +191,7 @@ namespace SyncKusto
         }
 
         /// <summary>
-        /// Get or set the most recently used clusters
+        /// Get or set the most recently used databases
         /// </summary>
         public static List<string> RecentDatabases
         {
@@ -220,6 +220,35 @@ namespace SyncKusto
         }
 
         /// <summary>
+        /// Get or set the most recently used application ids
+        /// </summary>
+        public static List<string> RecentAppIds
+        {
+            get
+            {
+                var currentValue = Settings.Default["RecentAppIds"] as StringCollection;
+                if (currentValue == null)
+                {
+                    return new List<string>();
+                }
+
+                return currentValue.Cast<string>().ToList();
+            }
+            set
+            {
+                if (!(value is IList<string>))
+                {
+                    throw new ArgumentException("Value must be of type IList<string>");
+                }
+
+                var sc = new StringCollection();
+                sc.AddRange(value.ToArray());
+                Settings.Default["RecentAppIds"] = sc;
+                Settings.Default.Save();
+            }
+        }
+
+        /// <summary>
         /// Include a cluster in the recent history list. If it's already in the list, it will be
         /// moved to the top of the list.
         /// </summary>
@@ -237,6 +266,16 @@ namespace SyncKusto
         public static void AddRecentDatabase(string database)
         {
             RecentDatabases = AddRecentItem(RecentDatabases, database);
+        }
+
+        /// <summary>
+        /// Include an application id in the recent history list. If it's already in the list, it
+        /// will be moved to the top of the list.
+        /// </summary>
+        /// <param name="applicationId">The application id to include</param>
+        public static void AddRecentAppId(string applicationId)
+        {
+            RecentAppIds = AddRecentItem(RecentAppIds, applicationId);
         }
 
         /// <summary>

--- a/SyncKusto/SettingsWrapper.cs
+++ b/SyncKusto/SettingsWrapper.cs
@@ -219,16 +219,35 @@ namespace SyncKusto
             }
         }
 
+        /// <summary>
+        /// Include a cluster in the recent history list. If it's already in the list, it will be
+        /// moved to the top of the list.
+        /// </summary>
+        /// <param name="cluster">The cluster to include</param>
         public static void AddRecentCluster(string cluster)
         {
             RecentClusters = AddRecentItem(RecentClusters, cluster);
         }
 
+        /// <summary>
+        /// Include a database in the recent history list. If it's already in the list, it will be
+        /// moved to the top of the list.
+        /// </summary>
+        /// <param name="database">The database to include</param>
         public static void AddRecentDatabase(string database)
         {
             RecentDatabases = AddRecentItem(RecentDatabases, database);
         }
 
+        /// <summary>
+        /// Make sure that an item is included in a list. If it's a new item, it gets added at the
+        /// top of the list. If it's an existing item, that item gets moved to the top of the list.
+        /// If the list is longer than 10 items, the least recently used items are truncated to get
+        /// back to 10.
+        /// </summary>
+        /// <param name="itemList">The list of items to update.</param>
+        /// <param name="item">The item to include in the list.</param>
+        /// <returns>The updated list of items.</returns>
         private static List<string> AddRecentItem(List<string> itemList, string item)
         {
             if (string.IsNullOrWhiteSpace(item))

--- a/SyncKusto/SettingsWrapper.cs
+++ b/SyncKusto/SettingsWrapper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using SyncKusto.Properties;
+using System;
 using System.Security.Cryptography.X509Certificates;
 
 namespace SyncKusto
@@ -131,21 +132,27 @@ namespace SyncKusto
         /// <summary>
         /// The certificate location to search use when displaing certs in the Subject Name Issuer cert picker.
         /// </summary>
-        public static string CertificateLocation
+        public static StoreLocation CertificateLocation
         {
             get
             {
                 var currentValue = Settings.Default["CertificateLocation"] as string;
                 if (string.IsNullOrWhiteSpace(currentValue))
                 {
-                    return StoreLocation.CurrentUser.ToString();
+                    return StoreLocation.CurrentUser;
                 }
 
-                return currentValue;
+                if (Enum.TryParse(currentValue, out StoreLocation result))
+                {
+                    return result;
+                }
+
+                // Couldn't parse so we'll go with CurrentUser.
+                return StoreLocation.CurrentUser;
             }
             set
             {
-                Settings.Default["CertificateLocation"] = value;
+                Settings.Default["CertificateLocation"] = value.ToString();
                 Settings.Default.Save();
             }
         }

--- a/SyncKusto/SettingsWrapper.cs
+++ b/SyncKusto/SettingsWrapper.cs
@@ -147,8 +147,7 @@ namespace SyncKusto
                     return result;
                 }
 
-                // Couldn't parse so we'll go with CurrentUser.
-                return StoreLocation.CurrentUser;
+                throw new Exception($"Could not map {currentValue} to StoreLocation enum type.");
             }
             set
             {

--- a/SyncKusto/SettingsWrapper.cs
+++ b/SyncKusto/SettingsWrapper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using SyncKusto.Properties;
+using System.Security.Cryptography.X509Certificates;
 
 namespace SyncKusto
 {
@@ -50,7 +51,7 @@ namespace SyncKusto
         }
 
         /// <summary>
-        /// The AAD Authority to use to authenticate a user. For user auth, this might work when it's empty depending on the tenant configuration, 
+        /// The AAD Authority to use to authenticate a user. For user auth, this might work when it's empty depending on the tenant configuration,
         /// but it's always required for AAD application auth.
         /// </summary>
         public static string AADAuthority
@@ -71,7 +72,7 @@ namespace SyncKusto
             get
             {
                 bool? currentSetting = Settings.Default["KustoObjectDropWarning"] as bool?;
-                return currentSetting??false;
+                return currentSetting ?? false;
             }
             set
             {
@@ -123,8 +124,30 @@ namespace SyncKusto
         /// Gets the file extension to use throughout the application when reading and writing Kusto files
         /// </summary>
         public static string FileExtension
-        { 
+        {
             get => SettingsWrapper.UseLegacyCslExtension.GetValueOrDefault() ? "csl" : "kql";
+        }
+
+        /// <summary>
+        /// The certificate location to search use when displaing certs in the Subject Name Issuer cert picker.
+        /// </summary>
+        public static string CertificateLocation
+        {
+            get
+            {
+                var currentValue = Settings.Default["CertificateLocation"] as string;
+                if (string.IsNullOrWhiteSpace(currentValue))
+                {
+                    return StoreLocation.CurrentUser.ToString();
+                }
+
+                return currentValue;
+            }
+            set
+            {
+                Settings.Default["CertificateLocation"] = value;
+                Settings.Default.Save();
+            }
         }
     }
 }

--- a/SyncKusto/Utilities/CertificateStore.cs
+++ b/SyncKusto/Utilities/CertificateStore.cs
@@ -30,16 +30,11 @@
         /// Get all the certificates in both the Current User and Local Machine locations.
         /// </summary>
         /// <returns>A collection of certificates</returns>
-        public static X509Certificate2Collection GetAllCertificates()
+        public static X509Certificate2Collection GetAllCertificates(StoreLocation storeLocation)
         {
-            X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+            var store = new X509Store(StoreName.My, storeLocation);
             store.Open(OpenFlags.ReadOnly);
-            X509Certificate2Collection certificates = store.Certificates;
-            store.Close();
-
-            store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
-            store.Open(OpenFlags.ReadOnly);
-            certificates.AddRange(store.Certificates);
+            var certificates = store.Certificates;
             store.Close();
 
             return certificates;


### PR DESCRIPTION
1) The certificate button for SNI auth now looks only at one location (either CurrentUser or LocalMachine) based on field in the Settings dialog.
2) The 10 most recently used cluster, database, and app ids are now stored in the user settings file and the list is updated each time a valid comparison is completed. Users can ignore this feature by continuing to type in their own strings or they can use the drop downs to populate a particular field.