### PR TITLE
Trim recently used values before storing

### DIFF
--- a/SyncKusto/MainForm.Designer.cs
+++ b/SyncKusto/MainForm.Designer.cs
@@ -150,7 +150,7 @@ namespace SyncKusto
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(81, 13);
             this.label2.TabIndex = 6;
-            this.label2.Text = "Build 20240422";
+            this.label2.Text = "Build 20240423";
             // 
             // spcTargetHolder
             // 

--- a/SyncKusto/SettingsWrapper.cs
+++ b/SyncKusto/SettingsWrapper.cs
@@ -294,6 +294,8 @@ namespace SyncKusto
                 return itemList;
             }
 
+            item = item.Trim();
+
             if (itemList.Contains(item))
             {
                 // To bubble this to the top we'll first remove it from the list and then the next


### PR DESCRIPTION
This avoids recently used entries that differ only by leading or trailing whitespace.