### PR TITLE
Kusto NuGet update to avoid hanging when trying to configure settings

### DIFF
--- a/SyncKusto/MainForm.Designer.cs
+++ b/SyncKusto/MainForm.Designer.cs
@@ -150,7 +150,7 @@ namespace SyncKusto
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(81, 13);
             this.label2.TabIndex = 6;
-            this.label2.Text = "Build 20240423";
+            this.label2.Text = "Build 20241018";
             // 
             // spcTargetHolder
             // 

--- a/SyncKusto/SyncKusto.csproj
+++ b/SyncKusto/SyncKusto.csproj
@@ -232,7 +232,7 @@
       <Version>1.4.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.Kusto.Data">
-      <Version>12.2.0</Version>
+      <Version>12.2.7</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>


### PR DESCRIPTION
A user was experiencing a hang when trying to save the Settings for the first time. It was happening where we connect to Kusto and verify that we can create/drop a function in the scratch database. I'm not sure why it was hanging instead of giving an error, but upgrading to the latest version of the NuGet package resolved it.