### PR TITLE
Update upload-artifacts to v4

### DIFF
--- a/.github/workflows/official.yml
+++ b/.github/workflows/official.yml
@@ -33,7 +33,7 @@ jobs:
       run: msbuild.exe SyncKusto.sln /p:Configuration=Release
         
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: published
         path: SyncKusto/bin/Release


### PR DESCRIPTION
The previous build definition stopped working. Information about the change is available here: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/